### PR TITLE
Don't prevent propagation and the browser's default action for non-handled keydown events.

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -33,6 +33,7 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
         });
         if (match) {
             match.callback.apply(this, arguments);
+            return true;
         }
     };
 
@@ -324,11 +325,11 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
                     return;
                 }
 
-                matchers.key.match(e, item);
-
-                // Prevent the event from propogating
-                e.preventDefault();
-                e.stopPropagation();
+                if (matchers.key.match(e, item)) {
+                    // Prevent the event from propagating if we handled it
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
             });
         }
     };


### PR DESCRIPTION
Previously keystrokes like CTRL+R were blocked when there was a focused item.
