### PR TITLE
Replace shift with shiftKey in the ctrl+shift+click handler

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -221,8 +221,8 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
                 };
 
                 matchers.click.register(
-                    { which: 1, ctrlKey: true, shift: true },
-                    { which: 1, metaKey: true, shift: true }, function (event, item) {
+                    { which: 1, ctrlKey: true, shiftKey: true },
+                    { which: 1, metaKey: true, shiftKey: true }, function (event, item) {
                     appendSelectionFromAnchor(item);
                 });
 


### PR DESCRIPTION
The ctrl+shift+click handler didn't work, due to a typo where it listened to shift:true instead of shiftKey:true
This commit fixes the typo (I'm Maarten btw)
