### PR TITLE
Pre-set selection doesnt work

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -273,8 +273,9 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
                 });
 
                 matchers.key.register({ which: 38 }, function (event, item) {
-                    selectItem(previousItem(item));
-                    anchor(item);
+                    var prev=previousItem(item);
+                    selectItem(prev);
+                    anchor(prev);
                 });
 
                 matchers.key.register(
@@ -294,8 +295,9 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
                 });
 
                 matchers.key.register({ which: 40 }, function (event, item) {
-                    selectItem(nextItem(item));
-                    anchor(item);
+                    var next=nextItem(item);
+                    selectItem(next);
+                    anchor(next);
                 });
 
                 matchers.key.register(


### PR DESCRIPTION
Found one more in the examples page - the pre-set selection used near the Template binding failed due to setAll and ko.utils.arrayForEach not unwrapping the selection observablArray itself. Manually unwrapping it fixes that.
