### PR TITLE
Renamed 'focus' config option to 'focused'

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -2,7 +2,7 @@
 /*
 data-bind="foreach: <observableArray>, selection: <observableArray>"
 
-data-bind="foreach: <observableArray>, selection: { data: <observableArray>, focus: <observable>, single: true, properties: { selected: 'selected', focused: 'focused'} }"
+data-bind="foreach: <observableArray>, selection: { data: <observableArray>, focused: <observable>, single: true, properties: { selected: 'selected', focused: 'focused'} }"
 */
 (function () {
     var eventComparison = function (pattern, event) {
@@ -86,7 +86,7 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
 
             if (bindingValue.data) {
                 selection = bindingValue.data;
-                focused = bindingValue.focus || ko.observable(null);
+                focused = bindingValue.focused || ko.observable(null);
                 anchor = bindingValue.anchor || ko.observable(null);
                 single = bindingValue.single === true;
                 ko.utils.extend(properties, bindingValue.properties);

--- a/test/index.html
+++ b/test/index.html
@@ -12,19 +12,19 @@
     <!-- Test elements -->
     <div style="display: none">
       <div id="single">
-        <ul data-bind="foreach: items, selection: { data: selection, single: true, focus: focus, anchor: anchor }" tabindex="-1">
+        <ul data-bind="foreach: items, selection: { data: selection, single: true, focused: focused, anchor: anchor }" tabindex="-1">
           <li data-bind="attr: { id: id }, css: { selected: selected }"></li>
         </ul>
       </div>
 
       <div id="multi">
-        <ul data-bind="foreach: items, selection: { data: selection, focus: focus, anchor: anchor }" tabindex="-1">
+        <ul data-bind="foreach: items, selection: { data: selection, focused: focused, anchor: anchor }" tabindex="-1">
           <li data-bind="attr: { id: id }, css: { selected: selected, focused: focused }"></li>
         </ul>
       </div>
 
       <div id="template">
-        <ul data-bind="template: { foreach: items, name: 'items-template' }, selection: { data: selection, focus: focus, anchor: anchor }" tabindex="-1"></ul>
+        <ul data-bind="template: { foreach: items, name: 'items-template' }, selection: { data: selection, focused: focused, anchor: anchor }" tabindex="-1"></ul>
       </div>
 
       <script type="text/html" id="items-template">
@@ -32,7 +32,7 @@
       </script>
 
       <div id="missing-foreach">
-        <ul data-bind="selection: { data: selection, focus: focus, anchor: anchor }" tabindex="-1">
+        <ul data-bind="selection: { data: selection, focused: focused, anchor: anchor }" tabindex="-1">
           <li data-bind="attr: { id: id }, css: { selected: selected, focused: focused }"></li>
         </ul>
       </div>

--- a/test/knockout.selection.spec.js
+++ b/test/knockout.selection.spec.js
@@ -17,13 +17,13 @@ describe('Selection', function () {
         model = {
             items: ko.observableArray(createItems(10)),
             selection: ko.observableArray(),
-            focus: ko.observable(),
+            focused: ko.observable(),
             anchor: ko.observable(),
             getItem: function (index) {
                 return this.items()[index];
             },
             focusItem: function (index) {
-                this.focus(this.getItem(index));
+                this.focused(this.getItem(index));
             },
             anchorItem: function (index) {
                 this.anchor(this.getItem(index));
@@ -162,7 +162,7 @@ describe('Selection', function () {
 
             it('keeps its selection and focused item after one of the unselected items is removed from the observable array', function () {
                 model.items.remove(model.getItem(6));
-                expect(model.focus()).to.be.ok();
+                expect(model.focused()).to.be.ok();
                 expect(element).to.have.selectionCount(1);
             });
 
@@ -173,7 +173,7 @@ describe('Selection', function () {
 
             it('has its focus observable set to null after the focused item is removed from the observable array', function () {
                 model.items.remove(model.getItem(7));
-                expect(model.focus()).to.not.be.ok();
+                expect(model.focused()).to.not.be.ok();
             });
 
             it('has its anchor observable set to null after the anchor item is removed from the observable array', function () {
@@ -186,9 +186,9 @@ describe('Selection', function () {
 
         it('focuses selected element', function () {
             click($('#item3'));
-            var focus = model.focus();
-            expect(focus.id).to.be('item3');
-            expect(focus.focused()).to.be.ok();
+            var focused = model.focused();
+            expect(focused.id).to.be('item3');
+            expect(focused.focused()).to.be.ok();
         });
     });
 
@@ -458,7 +458,7 @@ describe('Selection', function () {
 
             it('has its focused observable set to null after the focused item is removed from the observable array', function () {
                 model.items.remove(model.getItem(2));
-                expect(model.focus()).to.not.be.ok();
+                expect(model.focused()).to.not.be.ok();
             });
 
             it('has its anchor observable set to null after the anchor item is removed from the observable array', function () {
@@ -479,7 +479,7 @@ describe('Selection', function () {
         });
 
         it('updates the DOM when the focus changes', function () {
-            model.focus(model.items()[4]);
+            model.focused(model.items()[4]);
             expect(element).to.have.selectionCount(0);
             expect($('#item4')).to.have.cssClass('focused');
         });
@@ -496,7 +496,7 @@ describe('Selection', function () {
         });
 
         it('updates focused field of the items when the focus changes', function () {
-            model.focus(model.items()[4]);
+            model.focused(model.items()[4]);
             var focusCount = model.items().reduce(function (result, item) {
                 return result + item.focused();
             }, 0);


### PR DESCRIPTION
The name of the `focus` config option is a source of confusion. I keep getting it wrong in my code and noticed that there are also several errors in the tests and that it's pulled into a variable named `focused` in the code:

``` javascript
                focused = bindingValue.focus || ko.observable(null);
```

I say let's rip off the band-aid and change it.
