### PR TITLE
Four new tests for selection update after foreach change

### DIFF
--- a/test/knockout.selection.spec.js
+++ b/test/knockout.selection.spec.js
@@ -245,6 +245,24 @@ describe('Selection', function () {
                 });
 
             });
+
+            describe('when the content of foreach is altered', function () {
+
+                it('keeps items selected when they are still in foreach', function () {
+                    model.items ( model.items().slice(5) );
+
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item7')).to.have.cssClass('selected');
+                    expect(model.selection().length).to.be(1);
+                });
+
+                it('removes items from selection when they are removed from foreach', function () {
+                    model.items ( model.items().slice(0,4) );
+
+                    expect(element).to.have.selectionCount(0);
+                    expect(model.selection().length).to.be(0);
+                });
+            });
         });
 
         it('focuses selected element', function () {
@@ -603,7 +621,27 @@ describe('Selection', function () {
                     expect($('#item3')).to.have.cssClass('selected');
                     expect($('#item9')).to.have.cssClass('selected');
                 });
+            });
 
+            describe('when the content of foreach is altered', function () {
+
+                it('keeps items selected when they are still in the foreach', function () {
+                    model.items ( model.items().slice(2,8) );
+
+                    expect(element).to.have.selectionCount(3);
+                    [2,4,7].forEach(function (index) {
+                        expect($('#item'+index)).to.have.cssClass('selected');
+                    });
+                    expect(model.selection().length).to.be(3);
+                });
+
+                it('removes items from selection when they are removed from foreach', function () {
+                    model.items ( model.items().slice(5) );
+
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item7')).to.have.cssClass('selected');
+                    expect(model.selection().length).to.be(1);
+                });
             });
         });
 


### PR DESCRIPTION
These tests check if A) items removed from foreach are also removed from selection - and B) the inverse too (items that are not removed during a write to foreach should stay selected). The tests for A) fail, for B) pass.

Loosely related to issue #16 though probably needs a fix somewhere else, such as commit https://github.com/mwoc/knockout.selection/commit/2f3936
