### PR TITLE
Fix for Ctrl+A callback passing foreach array into selection by reference

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -186,7 +186,7 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
             }
 
             function selectAll() {
-                selection( foreach().slice() );
+                selection(foreach().slice());
             }
 
             function toggleSelection(item) {


### PR DESCRIPTION
This is to fix bug #37 uncovered earlier today.

There are no unit tests covering the fixed bug - I think a unit test for this would become too focused on the current code rather than functionality.

I've attached an extra commit which removes a few lines of duplicate code.
