### PR TITLE
Clicking on selected items selects the item on mouse up

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -241,6 +241,8 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
                 return matchers;
             }
 
+            var selectItemOnMouseUp = false;
+
             function createMultiModeEventMatchers() {
                 var matchers = {
                     click: new EventMatcher(),
@@ -265,8 +267,16 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
                 });
 
                 matchers.click.register({ which: 1 }, function (event, item) {
-                    selectItem(item);
-                    anchor(item);
+                    if (selection.indexOf(item) === -1) {
+                        // Item is not selected
+                        selectItem(item);
+                        anchor(item);
+                    } else {
+                        // Item is selected - update selection on mouse up
+                        // This will give drag and drop libraries the ability
+                        // to cancel the selection event.
+                        selectItemOnMouseUp = true;
+                    }
                 });
 
                 matchers.key.register({ which: 32 }, function (event, item) {
@@ -343,6 +353,20 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
                     return;
                 }
                 matchers.click.match(e, item);
+            });
+
+            ko.utils.registerEventHandler(element, 'mouseup', function (e) {
+                if (selectItemOnMouseUp) {
+                    var item = ko.dataFor(e.target);
+                    if (foreach.indexOf(item) === -1) {
+                        return;
+                    }
+
+                    selectItemOnMouseUp = false;
+
+                    selectItem(item);
+                    anchor(item);
+                }
             });
 
 

--- a/test/knockout.selection.spec.js
+++ b/test/knockout.selection.spec.js
@@ -611,6 +611,23 @@ describe('Selection', function () {
                 expect(model.anchor()).to.not.be.ok();
             });
 
+            it('is possible to cancel the selection event if the item is alreay selected', function () {
+                $('#item4').one('mouseup', function (e) {
+                    e.stopPropagation();
+                });
+
+                var focused = model.focused();
+                var anchor = model.anchor();
+
+                click($('#item4'));
+                expect(focused).to.be(model.focused());
+                expect(anchor).to.be(model.anchor());
+                expect(element).to.have.selectionCount(3);
+                [2, 4, 7].forEach(function (index) {
+                    expect($('#item' + index)).to.have.cssClass('selected');
+                });
+            });
+
             describe('when the selection is set manually', function () {
 
                 it('selects one item manually', function() {

--- a/test/spec.helper.js
+++ b/test/spec.helper.js
@@ -13,8 +13,9 @@ function click(element, options) {
         ctrlKey: false
     };
     options = $.extend(defaultOptions, options);
-    var e = $.Event("mousedown", options);
-    element.trigger(e);
+    element.trigger($.Event("mousedown", options));
+    element.trigger($.Event("mouseup", options));
+    element.trigger($.Event("click", options));
 }
 
 function keyDown(element, options) {


### PR DESCRIPTION
This change will support cancelling the selection by stopping
the event propagation of mouse up. This is necessary for
integration with drag and drap handlers, where we don't want
the selection to change when dragging multiple items.
