### PR TITLE
Validate selection/focused/anchor during initialization

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -46,9 +46,9 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
     };
 
     function createRange(foreach, start, end) {
-        var startIndex = foreach.indexOf(start),
-            endIndex = foreach.indexOf(end),
-            items = foreach(),
+        var items = foreach(),
+            startIndex = ko.utils.arrayIndexOf(items, start),
+            endIndex = ko.utils.arrayIndexOf(items, end),
             range = [];
 
         // Find the correct start and end position
@@ -130,16 +130,16 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
                 var allItems = foreach(),
                     stillPresentSelectedItems = [];
 
-                if (focused() && allItems.indexOf(focused()) === -1) {
+                if (focused() && ko.utils.arrayIndexOf(allItems, focused()) === -1) {
                     focused(null);
                 }
 
-                if (anchor() && allItems.indexOf(anchor()) === -1) {
+                if (anchor() && ko.utils.arrayIndexOf(allItems, anchor()) === -1) {
                     anchor(null);
                 }
 
                 ko.utils.arrayForEach(selection(), function (selectedItem) {
-                    if (allItems.indexOf(selectedItem) !== -1) {
+                    if (ko.utils.arrayIndexOf(allItems, selectedItem) !== -1) {
                         stillPresentSelectedItems.push(selectedItem);
                     }
                 });
@@ -172,7 +172,7 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
             }
 
             function isAlreadySelected(item) {
-                return selection.indexOf(item) !== -1;
+                return ko.utils.arrayIndexOf(selection(), item) !== -1;
             }
 
             function appendSelectionFromAnchor(item) {
@@ -219,13 +219,13 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
 
             function nextItem(item) {
                 var items = foreach(),
-                    position = items.indexOf(item);
+                    position = ko.utils.arrayIndexOf(items, item);
                 return items[Math.min(position + 1, items.length - 1)];
             }
 
             function previousItem(item) {
                 var items = foreach(),
-                    position = items.indexOf(item);
+                    position = ko.utils.arrayIndexOf(items, item);
                 return items[Math.max(position - 1, 0)];
             }
 
@@ -296,7 +296,7 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
                 });
 
                 matchers.click.register({ which: 1 }, function (event, item) {
-                    if (selection.indexOf(item) === -1) {
+                    if (ko.utils.arrayIndexOf(selection(), item) === -1) {
                         // Item is not selected
                         selectItem(item);
                         anchor(item);
@@ -425,8 +425,8 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
             var matchers = single ? createSingleModeEventMatchers() : createMultiModeEventMatchers();
 
             ko.utils.registerEventHandler(element, 'mousedown', function (e) {
-                var item = ko.dataFor(e.target);
-                if (foreach.indexOf(item) === -1) {
+                var item = ko.dataFor(e.target || e.srcElement);
+                if (ko.utils.arrayIndexOf(foreach(), item) === -1) {
                     return;
                 }
                 matchers.click.match(e, item);
@@ -434,8 +434,8 @@ data-bind="foreach: <observableArray>, selection: { data: <observableArray>, foc
 
             ko.utils.registerEventHandler(element, 'mouseup', function (e) {
                 if (selectItemOnMouseUp) {
-                    var item = ko.dataFor(e.target);
-                    if (foreach.indexOf(item) === -1) {
+                    var item = ko.dataFor(e.target || e.srcElement);
+                    if (ko.utils.arrayIndexOf(foreach(), item) === -1) {
                         return;
                     }
 


### PR DESCRIPTION
Cleanup selection state on initialization - for cases where an application has selection/focused/anchor on items which do not actually exist in foreach.

Added an extra commit for IE8 compatibility, where ko.utils.arrayForEach works but observableArray.forEach does not
