### PR TITLE
Change behaviour of space key in multi-select mode

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -291,12 +291,7 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
                 });
 
                 matchers.key.register({ which: 32 }, function (event, item) {
-                    if (event.ctrlKey || event.shiftKey) {
-                        selectItem(item);
-                        anchor(item);
-                    } else {
-                        toggleSelection(item);
-                    }
+                    toggleSelection(item);
                 });
 
                 matchers.key.register(

--- a/test/knockout.selection.spec.js
+++ b/test/knockout.selection.spec.js
@@ -483,6 +483,24 @@ describe('Selection', function () {
                 expect(element).to.have.selectionCount(4);
             });
 
+            it('ignores ctrl key on space', function () {
+                model.focusItem(6);
+                space($('ul', element), { ctrlKey: true });
+                [2, 4, 6, 7].forEach(function (index) {
+                    expect($('#item' + index)).to.have.cssClass('selected');
+                });
+                expect(element).to.have.selectionCount(4);
+            });
+
+            it('ignores shift key on space', function () {
+                model.focusItem(6);
+                space($('ul', element), { shiftKey: true });
+                [2, 4, 6, 7].forEach(function (index) {
+                    expect($('#item' + index)).to.have.cssClass('selected');
+                });
+                expect(element).to.have.selectionCount(4);
+            });
+
             it('maintains the selection of non-focused, but selected, elements on space', function () {
                 space($('ul', element));
                 [4, 7].forEach(function (index) {


### PR DESCRIPTION
Making it always execute toggleSelection gives an easier work flow when wanting to select several items which are not directly below each other - this pull request makes it possible to keep the ctrl key down while using the up/down keys and space button, while before one needed to lift the ctrl key before pressing space
