### PR TITLE
Handle nested scoping in foreach template

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -406,9 +406,17 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
 
             var matchers = single ? createSingleModeEventMatchers() : createMultiModeEventMatchers();
 
+            function findItemData(target) {
+                var context = ko.contextFor(target);
+                while (context && ko.utils.arrayIndexOf(foreach(), context.$data) === -1) {
+                    context = context.$parentContext;
+                }
+                return context && context.$data;
+            }
+
             ko.utils.registerEventHandler(element, 'mousedown', function (e) {
-                var item = ko.dataFor(e.target || e.srcElement);
-                if (ko.utils.arrayIndexOf(foreach(), item) === -1) {
+                var item = findItemData(e.target || e.srcElement);
+                if (!item) {
                     return;
                 }
                 matchers.click.match(e, item);
@@ -416,8 +424,8 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
 
             ko.utils.registerEventHandler(element, 'mouseup', function (e) {
                 if (selectItemOnMouseUp) {
-                    var item = ko.dataFor(e.target || e.srcElement);
-                    if (ko.utils.arrayIndexOf(foreach(), item) === -1) {
+                    var item = findItemData(e.target || e.srcElement);
+                    if (!item) {
                         return;
                     }
 

--- a/test/knockout.selection.spec.js
+++ b/test/knockout.selection.spec.js
@@ -867,4 +867,20 @@ describe('Selection', function () {
             }).to.throwException(/a object containing a `selection` `observableArray`/);
         });
     });
+
+    it('handles nested scoping', function () {
+        element = createTestElement(
+            'foreach: items, selection: { selection: selection, single: true, focused: focused, anchor: anchor }',
+            'attr: { id: id }, css: { selected: selected }, foreach: [0, 1, 2]'
+        );
+
+        $('li', element).each(function (index, el) {
+            $(el).append('<span data-bind="text: $data"></span>');
+        });
+
+        ko.applyBindings(model, element);
+        click($('#item3 span:first-child'));
+        expect(element).to.have.selectionCount(1);
+        expect($('#item3')).to.have.cssClass('selected');
+    });
 });


### PR DESCRIPTION
If you have a nested foreach or any other construct that creates a nested scope the selection model will not handle clicks on elements in the nested scope:

```
<ul data-bind="foreach: [0,1,2,3,4,5], selection: selection">
  <li data-bind="foreach: [0,1,2,3,4,5]">
    <div data-bind="text: $data"></div>
  </li>
</ul>
```

Clicking on the div-element will not select the parent li-element.

The pull request fixes this by walking up the context chain.
