### PR TITLE
Expand error message for missing this.items

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -60,7 +60,7 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
         var that = this;
 
         if (!this.items) {
-            throw new Error('The selection binding can only be used together with `foreach`, `foreach: { data: ... }` or `template: { foreach: ... }`.');
+            throw new Error('The selection binding can only be used together with `foreach`, `foreach: { data: ... }`, `template: { foreach: ... }` or like `selection: { data: ... }`.');
         }
 
         if (!ko.isObservable(this.selection)) {


### PR DESCRIPTION
Also explain one can pass items via `selection: { data: ... }`
