### PR TITLE
Use peek instead of unwrapping observables in SelectionModel.prototype.cleanup

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -111,10 +111,10 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
     };
 
     SelectionModel.prototype.cleanup = function () {
-        var allItems = this.items(),
+        var allItems = this.items.peek(),
             stillPresentSelectedItems = [];
 
-        if (this.focused() && ko.utils.arrayIndexOf(allItems, this.focused()) === -1) {
+        if (this.focused.peek() && ko.utils.arrayIndexOf(allItems, this.focused.peek()) === -1) {
             var focusOnIndex = Math.min(this.focusedIndex, allItems.length - 1);
             if (allItems[focusOnIndex]) {
                 this.focused(allItems[focusOnIndex]);
@@ -123,17 +123,17 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
             }
         }
 
-        if (this.anchor() && ko.utils.arrayIndexOf(allItems, this.anchor()) === -1) {
+        if (this.anchor.peek() && ko.utils.arrayIndexOf(allItems, this.anchor.peek()) === -1) {
             this.anchor(null);
         }
 
-        ko.utils.arrayForEach(this.selection(), function (selectedItem) {
+        ko.utils.arrayForEach(this.selection.peek(), function (selectedItem) {
             if (ko.utils.arrayIndexOf(allItems, selectedItem) !== -1) {
                 stillPresentSelectedItems.push(selectedItem);
             }
         });
 
-        if (stillPresentSelectedItems.length !== this.selection().length) {
+        if (stillPresentSelectedItems.length !== this.selection.peek().length) {
             this.selection(stillPresentSelectedItems);
         }
     };


### PR DESCRIPTION
I've found out the hard way again why this is necessary - it is to prevent subscribing to the observables, as subscribing to them will keep multiple instances of knockout.selection alive while only the newest should be.
