### PR TITLE
Allow drag and drop libraries to to cancel selection event in single mode

### DIFF
--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -268,9 +268,29 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
 
                 var matchers = new EventMatcher();
 
-                matchers.register({ type: 'mousedown', which: 1, hasItem: true }, function (event, item) {
+                var selectItemOnMouseUp = false;
+
+                function handleClick(element, event, item) {
                     selectionModel.selectItem(item);
                     selectionModel.anchor(item);
+                    selectItemOnMouseUp = false;
+                }
+
+                matchers.register({ type: 'mousedown', which: 1, hasItem: true }, function (event, item) {
+                    if (selectionModel.isAlreadySelected(item)) {
+                        // Item is selected - update selection on mouse up
+                        // This will give drag and drop libraries the ability
+                        // to cancel the selection event.
+                        selectItemOnMouseUp = true;
+                    } else {
+                        handleClick(this, event, item);
+                    }
+                });
+
+                matchers.register({ type: 'mouseup', which: 1, hasItem: true }, function (event, item) {
+                    if (selectItemOnMouseUp) {
+                        handleClick(this, event, item);
+                    }
                 });
 
                 matchers.register({ type: 'keydown', which: 32, hasItem: true }, function (event, item) {


### PR DESCRIPTION
This is already implemented for multi mode - we just forgot to do it for single mode.
