### PR TITLE
Introduce reusable isClickOnToggleElement event property instead of special-casing inside event handlers

### DIFF
--- a/lib/eventmatcher.js
+++ b/lib/eventmatcher.js
@@ -29,10 +29,10 @@
         }
     };
 
-    EventMatcher.prototype.match = function (event, item, element) {
+    EventMatcher.prototype.match = function (event, item) {
         for (var i = 0; i < this.handlers.length; i += 1) {
             if (compare(this.handlers[i].pattern, event)) {
-                this.handlers[i].callback.call(element, event, item);
+                this.handlers[i].callback.call(this, event, item);
                 return true;
             }
         }

--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -688,7 +688,7 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
                 e.hasItem = !!item;
                 e.isClickOnToggleElement = isClickOnToggleElement(this, e);
 
-                matchers.match(e, item, this);
+                matchers.match(e, item);
             }
 
             ko.utils.registerEventHandler(element, 'touchstart', matchEventWithItem);
@@ -703,7 +703,7 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
 
                 e.hasItem = !!item;
 
-                if (matchers.match(e, item, this)) {
+                if (matchers.match(e, item)) {
                     e.stopPropagation();
                     e.preventDefault();
                 }


### PR DESCRIPTION
With the toggle-element feature introduced recently, a few event handlers are given different behaviour if the click happens to be on a toggle element.

For reusability and clarity, it's much better to let that logic be handled by the EventMatcher, which is built for that task.

This pull request rewrites the new behaviour by using the EventMatcher.
