### PR TITLE
lateSelect flag selects on mouseup

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Example where the `toggleClass` is set to `checkbox`:
 </ul>
 ```
 
+### `lateSelect` \<boolean\>
+
+When `true`, delays selection of items to the `mouseup` event, which is useful when you need to intercept events, react to selections without interrupting either this library or for example drag-and-drop actions, etc. Mouseup events on a different element from the mousedown event will not select.
+
 ## Running the tests
 
 This test suite uses [Mocha](http://visionmedia.github.com/mocha/) and

--- a/lib/knockout.selection.js
+++ b/lib/knockout.selection.js
@@ -275,7 +275,7 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
                 var selectItemOnMouseUp = false;
 
                 matchers.register({ type: 'mousedown', which: 1, hasItem: true, isClickOnToggleElement: false }, function (event, item) {
-                    if (selectionModel.isAlreadySelected(item)) {
+                    if (selectionModel.lateSelect || selectionModel.isAlreadySelected(item)) {
                         // Item is selected - update selection on mouse up
                         // This will give drag and drop libraries the ability
                         // to cancel the selection event.
@@ -402,7 +402,7 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
                 var selectItemOnMouseUp = false;
 
                 matchers.register({ type: 'mousedown', which: 1, hasItem: true, isClickOnToggleElement: false }, function (event, item) {
-                    if (selectionModel.isAlreadySelected(item)) {
+                    if (selectionModel.lateSelect || selectionModel.isAlreadySelected(item)) {
                         // Item is selected - update selection on mouse up
                         // This will give drag and drop libraries the ability
                         // to cancel the selection event.
@@ -658,12 +658,15 @@ data-bind="selection: { data: <observableArray>, selection: <observableArray>, f
                 }
 
                 ko.utils.extend(config.properties, bindingValue.properties);
+
+                selectionModel.lateSelect = !!bindingValue.lateSelect;
             } else {
                 selectionModel.selection = value;
                 selectionModel.focused = ko.observable(null);
                 selectionModel.anchor = ko.observable(null);
                 selectionModel.mode = ko.observable(config.mode);
                 selectionModel.direction = ko.observable(config.direction);
+                selectionModel.lateSelect = false;
             }
 
             selectionModel.init(config);

--- a/test/knockout.selection.spec.js
+++ b/test/knockout.selection.spec.js
@@ -1584,7 +1584,7 @@ describe('Selection', function () {
         });
     });
 
-    describe('in late selection mode', function () {
+    describe('with late selection', function () {
         var items;
 
         beforeEach(function () {
@@ -1598,22 +1598,42 @@ describe('Selection', function () {
             ko.applyBindings(model, element);
         });
 
-        it('delays selection until mouseup in single mode', function () {
-            model.mode('single');
+        describe('in single mode', function () {
+            beforeEach(function () {
+                model.mode('single');
+            });
 
-            mousedown($('#item1'));
-            expect(model.selection().length).to.be(0);
-            mouseup($('#item1'));
-            expect(model.selection().length).to.be(1);
+            it('delays selection until mouseup on same element', function () {
+                mousedown($('#item1'));
+                expect(model.selection().length).to.be(0);
+                mouseup($('#item1'));
+                expect(model.selection().length).to.be(1);
+            });
+            it('does not select if mousedown and mouseup on different elements', function () {
+                mousedown($('#item1'));
+                expect(model.selection().length).to.be(0);
+                mouseup($('#item2'));
+                expect(model.selection().length).to.be(0);
+            });
         });
 
-        it('delays selection until mouseup in multi mode', function () {
-            model.mode('multi');
+        describe('in multi mode', function () {
+            beforeEach(function () {
+                model.mode('multi');
+            });
 
-            mousedown($('#item1'));
-            expect(model.selection().length).to.be(0);
-            mouseup($('#item1'));
-            expect(model.selection().length).to.be(1);
+            it('delays selection until mouseup on same element', function () {
+                mousedown($('#item1'));
+                expect(model.selection().length).to.be(0);
+                mouseup($('#item1'));
+                expect(model.selection().length).to.be(1);
+            });
+            it('does not select if mousedown and mouseup on different elements', function () {
+                mousedown($('#item1'));
+                expect(model.selection().length).to.be(0);
+                mouseup($('#item2'));
+                expect(model.selection().length).to.be(0);
+            });
         });
     });
 });

--- a/test/knockout.selection.spec.js
+++ b/test/knockout.selection.spec.js
@@ -1,5 +1,5 @@
 /*global describe, it, expect, beforeEach, afterEach, ko, $, toArray,
-         createTestElement, click, space, arrowDown, arrowUp, arrowRight, arrowLeft,
+         createTestElement, click, mousedown, mouseup, space, arrowDown, arrowUp, arrowRight, arrowLeft,
          keyDown, keyUp, home, end*/
 function createItems(size) {
     var result = [];
@@ -1581,6 +1581,39 @@ describe('Selection', function () {
             expect(function () {
                 model.mode('nonExistingModeName');
             }).to.throwException(/Unknown mode: "nonExistingModeName"/);
+        });
+    });
+
+    describe('in late selection mode', function () {
+        var items;
+
+        beforeEach(function () {
+            element = createTestElement(
+                'foreach: items, selection: { selection: selection, focused: focused, anchor: anchor, mode: mode, lateSelect: true }',
+                'attr: { id: id }, css: { selected: selected, focused: focused }'
+            );
+            items = createItems(2);
+            model.items = ko.observableArray(items);
+            model.mode = ko.observable('single');
+            ko.applyBindings(model, element);
+        });
+
+        it('delays selection until mouseup in single mode', function () {
+            model.mode('single');
+
+            mousedown($('#item1'));
+            expect(model.selection().length).to.be(0);
+            mouseup($('#item1'));
+            expect(model.selection().length).to.be(1);
+        });
+
+        it('delays selection until mouseup in multi mode', function () {
+            model.mode('multi');
+
+            mousedown($('#item1'));
+            expect(model.selection().length).to.be(0);
+            mouseup($('#item1'));
+            expect(model.selection().length).to.be(1);
         });
     });
 });

--- a/test/spec.helper.js
+++ b/test/spec.helper.js
@@ -35,6 +35,24 @@ function click(element, options) {
     element.trigger($.Event("mouseup", options));
     element.trigger($.Event("click", options));
 }
+function mousedown(element, options) {
+    var defaultOptions = {
+        which: 1,
+        shiftKey: false,
+        ctrlKey: false
+    };
+    options = $.extend(defaultOptions, options);
+    element.trigger($.Event("mousedown", options));
+}
+function mouseup(element, options) {
+    var defaultOptions = {
+        which: 1,
+        shiftKey: false,
+        ctrlKey: false
+    };
+    options = $.extend(defaultOptions, options);
+    element.trigger($.Event("mouseup", options));
+}
 
 function keyDown(element, options) {
     var defaultOptions = {


### PR DESCRIPTION
Added the above flag to allow selection on mouseup rather than mousedown, to avoid colliding with e.g. exit routing, drag&drop, etc. Defaults to false, so backwards compatible.
