### PR TITLE
Test suite upgrade, migrate to unexpected

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,16 +13,16 @@
     "test": "mocha-phantomjs test/phantomjs.html"
   },
   "devDependencies": {
-    "mocha": "=1.12.0",
-    "phantomjs": "=1.9.1-0",
-    "mocha-phantomjs": "=3.1.0",
     "expect.js": "=0.2.0",
-    "mocha-browserstack": "=0.2.1",
+    "mocha": "2.2.5",
+    "phantomjs": "1.9.7-15",
+    "mocha-phantomjs": "3.6.0",
+    "mocha-browserstack": "0.2.2",
     "grunt-exec": "=0.4.2",
     "grunt-contrib-connect": "=0.3.0",
     "grunt-contrib-watch": "=0.5.3",
     "grunt": "=0.4.1",
     "requirejs": "2.1.19"
   },
-  "license": "BSD-3-Clause" 
+  "license": "BSD-3-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "mocha-phantomjs test/phantomjs.html"
   },
   "devDependencies": {
-    "expect.js": "=0.2.0",
     "mocha": "2.2.5",
     "phantomjs": "1.9.7-15",
     "mocha-phantomjs": "3.6.0",
@@ -22,7 +21,8 @@
     "grunt-contrib-connect": "=0.3.0",
     "grunt-contrib-watch": "=0.5.3",
     "grunt": "=0.4.1",
-    "requirejs": "2.1.19"
+    "requirejs": "2.1.19",
+    "unexpected": "9.2.1"
   },
   "license": "BSD-3-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "grunt-exec": "=0.4.2",
     "grunt-contrib-connect": "=0.3.0",
     "grunt-contrib-watch": "=0.5.3",
-    "grunt": "=0.4.1"
+    "grunt": "=0.4.1",
+    "requirejs": "2.1.19"
   },
   "license": "BSD-3-Clause" 
 }

--- a/test/eventmatcher.spec.js
+++ b/test/eventmatcher.spec.js
@@ -1,7 +1,10 @@
 /*global describe, beforeEach, it */
 defineTest([
+    'unexpected',
     'lib/eventmatcher'
-], function (EventMatcher) {
+], function (unexpected, EventMatcher) {
+    var expect = unexpected.clone();
+
     describe('EventMatcher', function () {
         var eventMatcher = null;
 
@@ -10,12 +13,12 @@ defineTest([
         });
 
         it('has an empty handlers list', function () {
-            expect(eventMatcher.handlers).to.eql([]);
+            expect(eventMatcher.handlers, 'to equal', []);
         });
 
         it('matches with one handler and one matcher', function (done) {
             eventMatcher.register({ which: 1 }, function (e) {
-                expect(e).to.eql({ which: 1 });
+                expect(e, 'to equal', { which: 1 });
                 done();
             });
 
@@ -24,11 +27,11 @@ defineTest([
 
         it('matches with multiple handlers', function (done) {
             eventMatcher.register({ which: 1 }, function (e) {
-                expect(e).to.eql({ which: 1 });
+                expect(e, 'to equal', { which: 1 });
             });
 
             eventMatcher.register({ which: 2 }, function (e) {
-                expect(e).to.eql({ which: 2 });
+                expect(e, 'to equal', { which: 2 });
                 done();
             });
 

--- a/test/eventmatcher.spec.js
+++ b/test/eventmatcher.spec.js
@@ -1,43 +1,47 @@
-/*global describe, beforeEach, it, expect, EventMatcher*/
-describe('EventMatcher', function () {
-    var eventMatcher = null;
+/*global describe, beforeEach, it */
+defineTest([
+    'lib/eventmatcher'
+], function (EventMatcher) {
+    describe('EventMatcher', function () {
+        var eventMatcher = null;
 
-    beforeEach(function () {
-        eventMatcher = new EventMatcher();
-    });
-
-    it('has an empty handlers list', function () {
-        expect(eventMatcher.handlers).to.eql([]);
-    });
-
-    it('matches with one handler and one matcher', function (done) {
-        eventMatcher.register({ which: 1 }, function (e) {
-            expect(e).to.eql({ which: 1 });
-            done();
+        beforeEach(function () {
+            eventMatcher = new EventMatcher();
         });
 
-        eventMatcher.match({ which: 1 });
-    });
-
-    it('matches with multiple handlers', function (done) {
-        eventMatcher.register({ which: 1 }, function (e) {
-            expect(e).to.eql({ which: 1 });
+        it('has an empty handlers list', function () {
+            expect(eventMatcher.handlers).to.eql([]);
         });
 
-        eventMatcher.register({ which: 2 }, function (e) {
-            expect(e).to.eql({ which: 2 });
-            done();
+        it('matches with one handler and one matcher', function (done) {
+            eventMatcher.register({ which: 1 }, function (e) {
+                expect(e).to.eql({ which: 1 });
+                done();
+            });
+
+            eventMatcher.match({ which: 1 });
         });
 
-        eventMatcher.match({ which: 1 });
-        eventMatcher.match({ which: 2 });
-    });
+        it('matches with multiple handlers', function (done) {
+            eventMatcher.register({ which: 1 }, function (e) {
+                expect(e).to.eql({ which: 1 });
+            });
 
-    it('matches with multiple matchers', function (done) {
-        eventMatcher.register({ which: 1 }, { which: 2 }, function (e) {
-            done();
+            eventMatcher.register({ which: 2 }, function (e) {
+                expect(e).to.eql({ which: 2 });
+                done();
+            });
+
+            eventMatcher.match({ which: 1 });
+            eventMatcher.match({ which: 2 });
         });
 
-        eventMatcher.match({ which: 2 });
+        it('matches with multiple matchers', function (done) {
+            eventMatcher.register({ which: 1 }, { which: 2 }, function (e) {
+                done();
+            });
+
+            eventMatcher.match({ which: 2 });
+        });
     });
 });

--- a/test/index.html
+++ b/test/index.html
@@ -8,7 +8,6 @@
     <div id="mocha"></div>
     <div style="display: none" id="test"></div>
 
-    <script src="../vendor/expect.js"></script>
     <script src="../vendor/es5-shim.js"></script>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/mocha-browserstack/lib/mocha-browserstack.js"></script>
@@ -19,7 +18,8 @@
             baseUrl: '..',
             paths: {
                 jquery: 'vendor/jquery-1.10.2',
-                knockout: 'vendor/knockout-3.0.0.debug'
+                knockout: 'vendor/knockout-3.0.0.debug',
+                unexpected: 'node_modules/unexpected/unexpected'
             }
         };
     </script>

--- a/test/index.html
+++ b/test/index.html
@@ -9,19 +9,21 @@
     <div style="display: none" id="test"></div>
 
     <script src="../vendor/expect.js"></script>
+    <script src="../vendor/es5-shim.js"></script>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/mocha-browserstack/lib/mocha-browserstack.js"></script>
-    <script src="../vendor/jquery-1.10.2.js"></script>
-    <script src="../vendor/knockout-3.0.0.debug.js"></script>
-    <script src="../vendor/es5-shim.js"></script>
-    <script src="../lib/eventmatcher.js"></script>
-    <script src="../lib/knockout.selection.js"></script>
-    <script>mocha.ui('bdd').reporter(Mocha.BrowserStack);</script>
-    <script src="spec.helper.js"></script>
-    <script src="knockout.selection.spec.js"></script>
-    <script src="eventmatcher.spec.js"></script>
+    <script src="requirejs-mocha.js"></script>
+
     <script>
-        mocha.run();
+        var require = {
+            baseUrl: '..',
+            paths: {
+                jquery: 'vendor/jquery-1.10.2',
+                knockout: 'vendor/knockout-3.0.0.debug'
+            }
+        };
     </script>
+
+    <script src="../node_modules/requirejs/require.js" data-main="test/runner"></script>
   </body>
 </html>

--- a/test/knockout.selection.spec.js
+++ b/test/knockout.selection.spec.js
@@ -1,1586 +1,1590 @@
-/*global describe, it, expect, beforeEach, afterEach, ko, $, toArray,
-         createTestElement, click, space, arrowDown, arrowUp, arrowRight, arrowLeft,
-         keyDown, keyUp, home, end*/
-function createItems(size) {
-    var result = [];
+/*global describe, it, beforeEach, afterEach*/
+defineTest([
+    'jquery',
+    'knockout',
+    'test/spec.helper'
+], function ($, ko, specHelper) {
+    function createItems(size) {
+        var result = [];
 
-    for (var i = 0; i < size; i += 1) {
-        result.push({
-            id: 'item' + i,
-            selected: ko.observable(false),
-            focused: ko.observable(false)
-        });
+        for (var i = 0; i < size; i += 1) {
+            result.push({
+                id: 'item' + i,
+                selected: ko.observable(false),
+                focused: ko.observable(false)
+            });
+        }
+        return result;
     }
-    return result;
-}
 
-describe('Selection', function () {
-    var model, element;
-    beforeEach(function () {
-        model = {
-            items: ko.observableArray(createItems(10)),
-            selection: ko.observableArray(),
-            focused: ko.observable(),
-            anchor: ko.observable(),
-            getItem: function (index) {
-                return this.items()[index];
-            },
-            focusItem: function (index) {
-                this.focused(this.getItem(index));
-            },
-            anchorItem: function (index) {
-                this.anchor(this.getItem(index));
-            },
-            select: function () {
-                var that = this;
-                var indexes = toArray(arguments);
-                var newSelection = indexes.map(function (index) {
-                    return that.items()[index];
-                });
-                that.selection(newSelection);
-            }
-        };
-        model.itemsWrappedInAnObservable = ko.observable(model.items);
-    });
-
-    afterEach(function (done) {
-        // Use a setTimeout so IE8 doesn't run out of stack space (see
-        // https://github.com/visionmedia/mocha/issues/502)
-        window.setTimeout(function () {
-            done();
-        }, 0);
-    });
-
-    describe.skip('with a dynamic observable array bound to foreach', function () {
+    describe('Selection', function () {
+        var model, element;
         beforeEach(function () {
-            element = createTestElement(
-                "foreach: itemsWrappedInAnObservable(), selection: { selection: selection, mode: 'single', focused: focused, anchor: anchor }",
-                'attr: { id: id }, css: { selected: selected }'
-            );
-            ko.applyBindings(model, element);
+            model = {
+                items: ko.observableArray(createItems(10)),
+                selection: ko.observableArray(),
+                focused: ko.observable(),
+                anchor: ko.observable(),
+                getItem: function (index) {
+                    return this.items()[index];
+                },
+                focusItem: function (index) {
+                    this.focused(this.getItem(index));
+                },
+                anchorItem: function (index) {
+                    this.anchor(this.getItem(index));
+                },
+                select: function () {
+                    var that = this;
+                    var indexes = specHelper.toArray(arguments);
+                    var newSelection = indexes.map(function (index) {
+                        return that.items()[index];
+                    });
+                    that.selection(newSelection);
+                }
+            };
+            model.itemsWrappedInAnObservable = ko.observable(model.items);
         });
 
-        describe('with a selection', function () {
+        afterEach(function (done) {
+            // Use a setTimeout so IE8 doesn't run out of stack space (see
+            // https://github.com/visionmedia/mocha/issues/502)
+            window.setTimeout(function () {
+                done();
+            }, 0);
+        });
+
+        describe.skip('with a dynamic observable array bound to foreach', function () {
             beforeEach(function () {
-                model.select(7);
-                model.focusItem(7);
-                expect(element).to.have.selectionCount(1);
+                element = specHelper.createTestElement(
+                    "foreach: itemsWrappedInAnObservable(), selection: { selection: selection, mode: 'single', focused: focused, anchor: anchor }",
+                    'attr: { id: id }, css: { selected: selected }'
+                );
+                ko.applyBindings(model, element);
             });
 
-            it('empties its selection when the observableArray bound to the foreach changes', function () {
-                model.items = ko.observableArray(createItems(9));
-                model.itemsWrappedInAnObservable(model.items);
-                expect(model.selection().length).to.be(0);
-                expect(element).to.have.selectionCount(0);
-                expect(model.focused()).to.not.be.ok();
-                expect(model.anchor()).to.not.be.ok();
-            });
-        });
-    });
-
-    describe('in single selection mode', function () {
-        beforeEach(function () {
-            element = createTestElement(
-                "foreach: items, selection: { selection: selection, mode: 'single', focused: focused, anchor: anchor }",
-                'attr: { id: id }, css: { selected: selected }'
-            );
-            ko.applyBindings(model, element);
-        });
-
-        describe('with no selection', function () {
-            it('has no elements marked as selected', function () {
-                expect(element).to.have.selectionCount(0);
-            });
-
-            it('selects the clicked element', function () {
-                click($('#item3'));
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('select focused element on space', function () {
-                model.focusItem(3);
-                space($('ul', element));
-                expect($('#item3')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects the element after the focused element on down-arrow', function () {
-                model.focusItem(3);
-                arrowDown($('ul', element));
-                expect($('#item4')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects the element before the focused element on up-arrow', function () {
-                model.focusItem(3);
-                arrowUp($('ul', element));
-                expect($('#item2')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects first element on down-arrow when there is no focused item', function () {
-                arrowDown($('ul', element));
-                expect($('#item0')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects first element on up-arrow when there is no focused item', function () {
-                arrowUp($('ul', element));
-                expect($('#item0')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects first element on home', function () {
-                home($('ul', element));
-                expect($('#item0')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects last element on end', function () {
-                end($('ul', element));
-                expect($('#item9')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            describe('when first element is focused', function () {
+            describe('with a selection', function () {
                 beforeEach(function () {
-                    model.focusItem(0);
+                    model.select(7);
+                    model.focusItem(7);
+                    expect(element).to.have.selectionCount(1);
                 });
 
-                it('selects the focused element on up-arrow', function () {
-                    arrowUp($('ul', element));
+                it('empties its selection when the observableArray bound to the foreach changes', function () {
+                    model.items = ko.observableArray(createItems(9));
+                    model.itemsWrappedInAnObservable(model.items);
+                    expect(model.selection().length).to.be(0);
+                    expect(element).to.have.selectionCount(0);
+                    expect(model.focused()).to.not.be.ok();
+                    expect(model.anchor()).to.not.be.ok();
+                });
+            });
+        });
+
+        describe('in single selection mode', function () {
+            beforeEach(function () {
+                element = specHelper.createTestElement(
+                    "foreach: items, selection: { selection: selection, mode: 'single', focused: focused, anchor: anchor }",
+                    'attr: { id: id }, css: { selected: selected }'
+                );
+                ko.applyBindings(model, element);
+            });
+
+            describe('with no selection', function () {
+                it('has no elements marked as selected', function () {
+                    expect(element).to.have.selectionCount(0);
+                });
+
+                it('selects the clicked element', function () {
+                    specHelper.click($('#item3'));
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('select focused element on space', function () {
+                    model.focusItem(3);
+                    specHelper.space($('ul', element));
+                    expect($('#item3')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects the element after the focused element on down-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowDown($('ul', element));
+                    expect($('#item4')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects the element before the focused element on up-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowUp($('ul', element));
+                    expect($('#item2')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects first element on down-arrow when there is no focused item', function () {
+                    specHelper.arrowDown($('ul', element));
                     expect($('#item0')).to.have.cssClass('selected');
                     expect(element).to.have.selectionCount(1);
                 });
+
+                it('selects first element on up-arrow when there is no focused item', function () {
+                    specHelper.arrowUp($('ul', element));
+                    expect($('#item0')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects first element on home', function () {
+                    specHelper.home($('ul', element));
+                    expect($('#item0')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects last element on end', function () {
+                    specHelper.end($('ul', element));
+                    expect($('#item9')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                describe('when first element is focused', function () {
+                    beforeEach(function () {
+                        model.focusItem(0);
+                    });
+
+                    it('selects the focused element on up-arrow', function () {
+                        specHelper.arrowUp($('ul', element));
+                        expect($('#item0')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
+                });
+
+                describe('when last element is focused', function () {
+                    beforeEach(function () {
+                        model.focusItem(9);
+                    });
+
+                    it('selects the focused element on down-arrow', function () {
+                        specHelper.arrowDown($('ul', element));
+                        expect($('#item9')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
+                });
+
+                describe('when the selection is set manually', function () {
+
+                    it('selects one item manually', function () {
+                        model.selection([model.items()[3]]);
+
+                        expect($('#item3')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
+
+                    it('selects multiple items manually', function () {
+                        model.selection([model.items()[3], model.items()[9]]);
+
+                        expect(element).to.have.selectionCount(1);
+                        expect($('#item9')).to.have.cssClass('selected');
+                    });
+
+                });
             });
 
-            describe('when last element is focused', function () {
+            describe('with one selected item', function () {
                 beforeEach(function () {
-                    model.focusItem(9);
+                    model.select(7);
+                    model.focusItem(7);
                 });
 
-                it('selects the focused element on down-arrow', function () {
-                    arrowDown($('ul', element));
-                    expect($('#item9')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
-                });
-            });
-
-            describe('when the selection is set manually', function () {
-
-                it('selects one item manually', function () {
-                    model.selection([model.items()[3]]);
-
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
-                });
-
-                it('selects multiple items manually', function () {
-                    model.selection([model.items()[3], model.items()[9]]);
-
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item9')).to.have.cssClass('selected');
-                });
-
-            });
-        });
-
-        describe('with one selected item', function () {
-            beforeEach(function () {
-                model.select(7);
-                model.focusItem(7);
-            });
-
-            it('has one selection', function () {
-                expect(element).to.have.selectionCount(1);
-                expect($('#item7')).to.have.cssClass('selected');
-            });
-
-            it('moves the selection to the clicked element', function () {
-                click($('#item3'));
-                expect(element).to.have.selectionCount(1);
-                expect($('#item3')).to.have.cssClass('selected');
-                expect($('#item7')).to.not.have.cssClass('selected');
-            });
-
-            it('ignores clicks on selected element', function () {
-                click($('#item7'));
-                expect(element).to.have.selectionCount(1);
-                expect($('#item7')).to.have.cssClass('selected');
-            });
-
-            it('ignores shift', function () {
-                click($('#item3'), { shiftKey: true });
-                expect(element).to.have.selectionCount(1);
-                expect($('#item3')).to.have.cssClass('selected');
-                expect($('#item4')).to.not.have.cssClass('selected');
-                expect($('#item7')).to.not.have.cssClass('selected');
-            });
-
-            it('ignores ctrl', function () {
-                click($('#item3'), { ctrlKey: true });
-                expect(element).to.have.selectionCount(1);
-                expect($('#item3')).to.have.cssClass('selected');
-                expect($('#item7')).to.not.have.cssClass('selected');
-            });
-
-            it('selects next element on down-arrow', function () {
-                arrowDown($('ul', element));
-                expect($('#item7')).to.not.have.cssClass('selected');
-                expect($('#item8')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects previous element on up-arrow', function () {
-                arrowUp($('ul', element));
-                expect($('#item7')).to.not.have.cssClass('selected');
-                expect($('#item6')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('deselects item on space', function () {
-                space($('ul', element));
-                expect($('#item7')).to.not.have.cssClass('selected');
-                expect(element).to.have.selectionCount(0);
-            });
-
-            it('selects first element on home', function () {
-                home($('ul', element));
-                expect($('#item0')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects last element on end', function () {
-                end($('ul', element));
-                expect($('#item9')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('keeps its selection and focused item after one of the unselected items is removed from the observable array', function () {
-                model.items.remove(model.getItem(6));
-                expect(model.focused()).to.be.ok();
-                expect(element).to.have.selectionCount(1);
-                expect(model.selection().length).to.be(1);
-            });
-
-            it('has no selection after the selected item is removed from the observable array', function () {
-                model.items.remove(model.getItem(7));
-                expect(element).to.have.selectionCount(0);
-                expect(model.selection().length).to.be(0);
-            });
-
-            it('focuses the item at the same index after the focused item is removed from the observable array', function () {
-                model.items.remove(model.getItem(7));
-                expect(model.focused()).to.be(model.getItem(7));
-                expect(model.focused().id).to.be('item8');
-            });
-
-            it('focuses the new last item if the last item was focused and removed from the observable array', function () {
-                model.focusItem(9);
-                model.items.remove(model.getItem(9));
-                expect(model.focused()).to.be(model.getItem(8));
-                expect(model.focused().id).to.be('item8');
-            });
-
-            it('has its anchor observable set to null after the anchor item is removed from the observable array', function () {
-                model.anchorItem(7);
-                expect(model.anchor()).to.be.ok();
-                model.items.remove(model.getItem(7));
-                expect(model.anchor()).to.not.be.ok();
-            });
-
-            describe('when the selection is set manually', function () {
-
-                it('selects one item manually', function () {
-                    model.selection([model.items()[3]]);
-
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
-                });
-
-                it('selects multiple items manually', function () {
-                    model.selection([model.items()[3], model.items()[9]]);
-
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item9')).to.have.cssClass('selected');
-                });
-
-            });
-
-            describe('when the content of foreach is altered', function () {
-
-                it('keeps items selected when they are still in foreach', function () {
-                    model.items(model.items().slice(5));
-
+                it('has one selection', function () {
                     expect(element).to.have.selectionCount(1);
                     expect($('#item7')).to.have.cssClass('selected');
+                });
+
+                it('moves the selection to the clicked element', function () {
+                    specHelper.click($('#item3'));
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item3')).to.have.cssClass('selected');
+                    expect($('#item7')).to.not.have.cssClass('selected');
+                });
+
+                it('ignores clicks on selected element', function () {
+                    specHelper.click($('#item7'));
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item7')).to.have.cssClass('selected');
+                });
+
+                it('ignores shift', function () {
+                    specHelper.click($('#item3'), { shiftKey: true });
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item3')).to.have.cssClass('selected');
+                    expect($('#item4')).to.not.have.cssClass('selected');
+                    expect($('#item7')).to.not.have.cssClass('selected');
+                });
+
+                it('ignores ctrl', function () {
+                    specHelper.click($('#item3'), { ctrlKey: true });
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item3')).to.have.cssClass('selected');
+                    expect($('#item7')).to.not.have.cssClass('selected');
+                });
+
+                it('selects next element on down-arrow', function () {
+                    specHelper.arrowDown($('ul', element));
+                    expect($('#item7')).to.not.have.cssClass('selected');
+                    expect($('#item8')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects previous element on up-arrow', function () {
+                    specHelper.arrowUp($('ul', element));
+                    expect($('#item7')).to.not.have.cssClass('selected');
+                    expect($('#item6')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('deselects item on space', function () {
+                    specHelper.space($('ul', element));
+                    expect($('#item7')).to.not.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(0);
+                });
+
+                it('selects first element on home', function () {
+                    specHelper.home($('ul', element));
+                    expect($('#item0')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects last element on end', function () {
+                    specHelper.end($('ul', element));
+                    expect($('#item9')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('keeps its selection and focused item after one of the unselected items is removed from the observable array', function () {
+                    model.items.remove(model.getItem(6));
+                    expect(model.focused()).to.be.ok();
+                    expect(element).to.have.selectionCount(1);
                     expect(model.selection().length).to.be(1);
                 });
 
-                it('removes items from selection when they are removed from foreach', function () {
-                    model.items(model.items().slice(0, 4));
-
+                it('has no selection after the selected item is removed from the observable array', function () {
+                    model.items.remove(model.getItem(7));
                     expect(element).to.have.selectionCount(0);
                     expect(model.selection().length).to.be(0);
                 });
-            });
-        });
 
-        it('focuses selected element', function () {
-            click($('#item3'));
-            var focused = model.focused();
-            expect(focused.id).to.be('item3');
-            expect(focused.focused()).to.be.ok();
-        });
-    });
-
-    describe('in single selection mode, horizontal', function () {
-        beforeEach(function () {
-            element = createTestElement(
-                "foreach: items, selection: { selection: selection, mode: 'single', direction: 'horizontal', focused: focused, anchor: anchor }",
-                'attr: { id: id }, css: { selected: selected }'
-            );
-            ko.applyBindings(model, element);
-        });
-
-        describe('with no selection', function () {
-            it('selects the element after the focused element on right-arrow', function () {
-                model.focusItem(3);
-                arrowRight($('ul', element));
-                expect($('#item4')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects the element before the focused element on left-arrow', function () {
-                model.focusItem(3);
-                arrowLeft($('ul', element));
-                expect($('#item2')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects the first element on right-arrow when there is no focus', function () {
-                arrowRight($('ul', element));
-                expect($('#item0')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects the first element on left-arrow when there is no focus', function () {
-                arrowLeft($('ul', element));
-                expect($('#item0')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            describe('when first element is focused', function () {
-                beforeEach(function () {
-                    model.focusItem(0);
+                it('focuses the item at the same index after the focused item is removed from the observable array', function () {
+                    model.items.remove(model.getItem(7));
+                    expect(model.focused()).to.be(model.getItem(7));
+                    expect(model.focused().id).to.be('item8');
                 });
 
-                it('selects the focused element on left-arrow', function () {
-                    arrowLeft($('ul', element));
+                it('focuses the new last item if the last item was focused and removed from the observable array', function () {
+                    model.focusItem(9);
+                    model.items.remove(model.getItem(9));
+                    expect(model.focused()).to.be(model.getItem(8));
+                    expect(model.focused().id).to.be('item8');
+                });
+
+                it('has its anchor observable set to null after the anchor item is removed from the observable array', function () {
+                    model.anchorItem(7);
+                    expect(model.anchor()).to.be.ok();
+                    model.items.remove(model.getItem(7));
+                    expect(model.anchor()).to.not.be.ok();
+                });
+
+                describe('when the selection is set manually', function () {
+
+                    it('selects one item manually', function () {
+                        model.selection([model.items()[3]]);
+
+                        expect($('#item3')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
+
+                    it('selects multiple items manually', function () {
+                        model.selection([model.items()[3], model.items()[9]]);
+
+                        expect(element).to.have.selectionCount(1);
+                        expect($('#item9')).to.have.cssClass('selected');
+                    });
+
+                });
+
+                describe('when the content of foreach is altered', function () {
+
+                    it('keeps items selected when they are still in foreach', function () {
+                        model.items(model.items().slice(5));
+
+                        expect(element).to.have.selectionCount(1);
+                        expect($('#item7')).to.have.cssClass('selected');
+                        expect(model.selection().length).to.be(1);
+                    });
+
+                    it('removes items from selection when they are removed from foreach', function () {
+                        model.items(model.items().slice(0, 4));
+
+                        expect(element).to.have.selectionCount(0);
+                        expect(model.selection().length).to.be(0);
+                    });
+                });
+            });
+
+            it('focuses selected element', function () {
+                specHelper.click($('#item3'));
+                var focused = model.focused();
+                expect(focused.id).to.be('item3');
+                expect(focused.focused()).to.be.ok();
+            });
+        });
+
+        describe('in single selection mode, horizontal', function () {
+            beforeEach(function () {
+                element = specHelper.createTestElement(
+                    "foreach: items, selection: { selection: selection, mode: 'single', direction: 'horizontal', focused: focused, anchor: anchor }",
+                    'attr: { id: id }, css: { selected: selected }'
+                );
+                ko.applyBindings(model, element);
+            });
+
+            describe('with no selection', function () {
+                it('selects the element after the focused element on right-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowRight($('ul', element));
+                    expect($('#item4')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects the element before the focused element on left-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowLeft($('ul', element));
+                    expect($('#item2')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects the first element on right-arrow when there is no focus', function () {
+                    specHelper.arrowRight($('ul', element));
                     expect($('#item0')).to.have.cssClass('selected');
                     expect(element).to.have.selectionCount(1);
                 });
-            });
 
-            describe('when last element is focused', function () {
-                beforeEach(function () {
-                    model.focusItem(9);
-                });
-
-                it('selects the focused element on right-arrow', function () {
-                    arrowRight($('ul', element));
-                    expect($('#item9')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
-                });
-            });
-        });
-
-        describe('with one selected item', function () {
-            beforeEach(function () {
-                model.select(7);
-                model.focusItem(7);
-            });
-
-            it('selects next element on right-arrow', function () {
-                arrowRight($('ul', element));
-                expect($('#item7')).to.not.have.cssClass('selected');
-                expect($('#item8')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects previous element on left-arrow', function () {
-                arrowLeft($('ul', element));
-                expect($('#item7')).to.not.have.cssClass('selected');
-                expect($('#item6')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-        });
-    });
-
-    describe('in toggle selection mode', function () {
-        beforeEach(function () {
-            element = createTestElement(
-                "foreach: items, selection: { selection: selection, mode: 'toggle', focused: focused, anchor: anchor }",
-                'attr: { id: id }, css: { selected: selected }'
-            );
-            ko.applyBindings(model, element);
-        });
-
-        describe('with no selection', function () {
-            it('has no elements marked as selected', function () {
-                expect(element).to.have.selectionCount(0);
-            });
-
-            it('selects the clicked element', function () {
-                click($('#item3'));
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('select focused element on space', function () {
-                model.focusItem(3);
-                space($('ul', element));
-                expect($('#item3')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-        });
-
-        describe('with one item selected', function () {
-            beforeEach(function () {
-                model.select(7);
-                model.focusItem(7);
-            });
-
-            it('should have one selected item', function () {
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects another item', function () {
-                click($('#item3'));
-                expect(element).to.have.selectionCount(2);
-            });
-
-            it('deselects an item by selecting it', function () {
-                click($('#item7'));
-                expect(element).to.have.selectionCount(0);
-            });
-        });
-    });
-
-    describe('in off selection mode', function () {
-        beforeEach(function () {
-            element = createTestElement(
-                "foreach: items, selection: { selection: selection, mode: 'off', focused: focused, anchor: anchor }",
-                'attr: { id: id }, css: { selected: selected }'
-            );
-            ko.applyBindings(model, element);
-        });
-
-        describe('with no selection', function () {
-            it('has no elements marked as selected', function () {
-                expect(element).to.have.selectionCount(0);
-            });
-
-            it('does not select the clicked element', function () {
-                click($('#item3'));
-                expect(element).to.have.selectionCount(0);
-            });
-
-            it('does not select focused element on space', function () {
-                model.focusItem(3);
-                space($('ul', element));
-                expect(element).to.have.selectionCount(0);
-            });
-        });
-
-        describe('with one item selected', function () {
-            beforeEach(function () {
-                model.select(7);
-                model.focusItem(7);
-            });
-
-            it('should have one selected item', function () {
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('should not select another item', function () {
-                click($('#item3'));
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('should not deselect an item by selecting it', function () {
-                click($('#item7'));
-                expect(element).to.have.selectionCount(1);
-            });
-        });
-    });
-
-    describe('in multiple selection mode', function () {
-        beforeEach(function () {
-            element = createTestElement(
-                'foreach: items, selection: { selection: selection, focused: focused, anchor: anchor, toggleClass: \'checkbox\' }'
-            );
-
-            var item = $('<li data-bind="attr: { id: id }, css: { selected: selected, focused: focused }">' +
-                         '  <span class="checkbox">' +
-                         '    <span class="inside-checkbox"></span>' +
-                         '  </span>' +
-                         '</li>');
-
-            $('ul', element).append(item);
-
-            ko.applyBindings(model, element);
-        });
-
-        describe('with no selection', function () {
-            it('has no elements marked as selected', function () {
-                expect(element).to.have.selectionCount(0);
-            });
-
-            it('selects the clicked element', function () {
-                click($('#item3'));
-                expect(element).to.have.selectionCount(1);
-                expect($('#item3')).to.have.cssClass('selected');
-            });
-
-            it('selects the clicked element on shift-click', function () {
-                click($('#item3'), { shiftKey: true });
-                expect(element).to.have.selectionCount(1);
-                expect($('#item3')).to.have.cssClass('selected');
-            });
-
-            it('selects the clicked element on ctrl-click', function () {
-                click($('#item3'), { ctrlKey: true });
-                expect(element).to.have.selectionCount(1);
-                expect($('#item3')).to.have.cssClass('selected');
-            });
-
-            it('select focused element on space', function () {
-                model.focusItem(3);
-                space($('ul', element));
-                expect($('#item3')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects first element on home', function () {
-                home($('ul', element));
-                expect($('#item0')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects last element on end', function () {
-                end($('ul', element));
-                expect($('#item9')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects the element after the focused element on down-arrow', function () {
-                model.focusItem(3);
-                arrowDown($('ul', element));
-                expect($('#item4')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects the element before the focused element on up-arrow', function () {
-                model.focusItem(3);
-                arrowUp($('ul', element));
-                expect($('#item2')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects first element on up-arrow when there is no focused element', function () {
-                arrowUp($('ul', element));
-                expect($('#item0')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects first element on down-arrow when there is no focused element', function () {
-                arrowDown($('ul', element));
-                expect($('#item0')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects and focuses the element after the focused element on shift-down-arrow', function () {
-                model.focusItem(3);
-                model.anchorItem(3);
-                arrowDown($('ul', element), { shiftKey: true });
-                expect($('#item3')).to.have.cssClass('selected');
-                expect($('#item4')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(2);
-            });
-
-            it('selects and focuses the element before the focused element on shift-up-arrow', function () {
-                model.focusItem(3);
-                model.anchorItem(3);
-                arrowUp($('ul', element), { shiftKey: true });
-                expect($('#item3')).to.have.cssClass('selected');
-                expect($('#item2')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(2);
-            });
-
-            it('selects everything on ctrl-a', function () {
-                keyDown($('ul', element), { ctrlKey: true, which: 65 });
-                expect(element).to.have.selectionCount(10);
-            });
-
-            describe('when first element is focused', function () {
-                beforeEach(function () {
-                    model.focusItem(0);
-                });
-
-                it('selects the focused element on up-arrow', function () {
-                    arrowUp($('ul', element));
+                it('selects the first element on left-arrow when there is no focus', function () {
+                    specHelper.arrowLeft($('ul', element));
                     expect($('#item0')).to.have.cssClass('selected');
                     expect(element).to.have.selectionCount(1);
                 });
-            });
 
-            describe('when last element is focused', function () {
-                beforeEach(function () {
-                    model.focusItem(9);
+                describe('when first element is focused', function () {
+                    beforeEach(function () {
+                        model.focusItem(0);
+                    });
+
+                    it('selects the focused element on left-arrow', function () {
+                        specHelper.arrowLeft($('ul', element));
+                        expect($('#item0')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
                 });
 
-                it('selects the focused element on down-arrow', function () {
-                    arrowDown($('ul', element));
-                    expect($('#item9')).to.have.cssClass('selected');
+                describe('when last element is focused', function () {
+                    beforeEach(function () {
+                        model.focusItem(9);
+                    });
+
+                    it('selects the focused element on right-arrow', function () {
+                        specHelper.arrowRight($('ul', element));
+                        expect($('#item9')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
+                });
+            });
+
+            describe('with one selected item', function () {
+                beforeEach(function () {
+                    model.select(7);
+                    model.focusItem(7);
+                });
+
+                it('selects next element on right-arrow', function () {
+                    specHelper.arrowRight($('ul', element));
+                    expect($('#item7')).to.not.have.cssClass('selected');
+                    expect($('#item8')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects previous element on left-arrow', function () {
+                    specHelper.arrowLeft($('ul', element));
+                    expect($('#item7')).to.not.have.cssClass('selected');
+                    expect($('#item6')).to.have.cssClass('selected');
                     expect(element).to.have.selectionCount(1);
                 });
             });
+        });
 
-            describe('when the selection is set manually', function () {
+        describe('in toggle selection mode', function () {
+            beforeEach(function () {
+                element = specHelper.createTestElement(
+                    "foreach: items, selection: { selection: selection, mode: 'toggle', focused: focused, anchor: anchor }",
+                    'attr: { id: id }, css: { selected: selected }'
+                );
+                ko.applyBindings(model, element);
+            });
 
-                it('selects one item manually', function () {
-                    model.selection([model.items()[3]]);
+            describe('with no selection', function () {
+                it('has no elements marked as selected', function () {
+                    expect(element).to.have.selectionCount(0);
+                });
 
+                it('selects the clicked element', function () {
+                    specHelper.click($('#item3'));
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('select focused element on space', function () {
+                    model.focusItem(3);
+                    specHelper.space($('ul', element));
                     expect($('#item3')).to.have.cssClass('selected');
                     expect(element).to.have.selectionCount(1);
                 });
+            });
 
-                it('selects multiple items manually', function () {
-                    model.selection([model.items()[3], model.items()[9]]);
+            describe('with one item selected', function () {
+                beforeEach(function () {
+                    model.select(7);
+                    model.focusItem(7);
+                });
 
+                it('should have one selected item', function () {
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects another item', function () {
+                    specHelper.click($('#item3'));
                     expect(element).to.have.selectionCount(2);
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect($('#item9')).to.have.cssClass('selected');
                 });
 
+                it('deselects an item by selecting it', function () {
+                    specHelper.click($('#item7'));
+                    expect(element).to.have.selectionCount(0);
+                });
             });
         });
 
-        describe('with selected items', function () {
+        describe('in off selection mode', function () {
             beforeEach(function () {
-                model.select(7, 4, 2);
-                model.focusItem(2);
-                model.anchorItem(2);
+                element = specHelper.createTestElement(
+                    "foreach: items, selection: { selection: selection, mode: 'off', focused: focused, anchor: anchor }",
+                    'attr: { id: id }, css: { selected: selected }'
+                );
+                ko.applyBindings(model, element);
             });
 
-            it('expands the selection with ctrl-click', function () {
-                click($('#item3'), { ctrlKey: true });
+            describe('with no selection', function () {
+                it('has no elements marked as selected', function () {
+                    expect(element).to.have.selectionCount(0);
+                });
+
+                it('does not select the clicked element', function () {
+                    specHelper.click($('#item3'));
+                    expect(element).to.have.selectionCount(0);
+                });
+
+                it('does not select focused element on space', function () {
+                    model.focusItem(3);
+                    specHelper.space($('ul', element));
+                    expect(element).to.have.selectionCount(0);
+                });
+            });
+
+            describe('with one item selected', function () {
+                beforeEach(function () {
+                    model.select(7);
+                    model.focusItem(7);
+                });
+
+                it('should have one selected item', function () {
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('should not select another item', function () {
+                    specHelper.click($('#item3'));
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('should not deselect an item by selecting it', function () {
+                    specHelper.click($('#item7'));
+                    expect(element).to.have.selectionCount(1);
+                });
+            });
+        });
+
+        describe('in multiple selection mode', function () {
+            beforeEach(function () {
+                element = specHelper.createTestElement(
+                    'foreach: items, selection: { selection: selection, focused: focused, anchor: anchor, toggleClass: \'checkbox\' }'
+                );
+
+                var item = $('<li data-bind="attr: { id: id }, css: { selected: selected, focused: focused }">' +
+                             '  <span class="checkbox">' +
+                             '    <span class="inside-checkbox"></span>' +
+                             '  </span>' +
+                             '</li>');
+
+                $('ul', element).append(item);
+
+                ko.applyBindings(model, element);
+            });
+
+            describe('with no selection', function () {
+                it('has no elements marked as selected', function () {
+                    expect(element).to.have.selectionCount(0);
+                });
+
+                it('selects the clicked element', function () {
+                    specHelper.click($('#item3'));
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item3')).to.have.cssClass('selected');
+                });
+
+                it('selects the clicked element on shift-click', function () {
+                    specHelper.click($('#item3'), { shiftKey: true });
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item3')).to.have.cssClass('selected');
+                });
+
+                it('selects the clicked element on ctrl-click', function () {
+                    specHelper.click($('#item3'), { ctrlKey: true });
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item3')).to.have.cssClass('selected');
+                });
+
+                it('select focused element on space', function () {
+                    model.focusItem(3);
+                    specHelper.space($('ul', element));
+                    expect($('#item3')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects first element on home', function () {
+                    specHelper.home($('ul', element));
+                    expect($('#item0')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects last element on end', function () {
+                    specHelper.end($('ul', element));
+                    expect($('#item9')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects the element after the focused element on down-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowDown($('ul', element));
+                    expect($('#item4')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects the element before the focused element on up-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowUp($('ul', element));
+                    expect($('#item2')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects first element on up-arrow when there is no focused element', function () {
+                    specHelper.arrowUp($('ul', element));
+                    expect($('#item0')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects first element on down-arrow when there is no focused element', function () {
+                    specHelper.arrowDown($('ul', element));
+                    expect($('#item0')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
+
+                it('selects and focuses the element after the focused element on shift-down-arrow', function () {
+                    model.focusItem(3);
+                    model.anchorItem(3);
+                    specHelper.arrowDown($('ul', element), { shiftKey: true });
+                    expect($('#item3')).to.have.cssClass('selected');
+                    expect($('#item4')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(2);
+                });
+
+                it('selects and focuses the element before the focused element on shift-up-arrow', function () {
+                    model.focusItem(3);
+                    model.anchorItem(3);
+                    specHelper.arrowUp($('ul', element), { shiftKey: true });
+                    expect($('#item3')).to.have.cssClass('selected');
+                    expect($('#item2')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(2);
+                });
+
+                it('selects everything on ctrl-a', function () {
+                    specHelper.keyDown($('ul', element), { ctrlKey: true, which: 65 });
+                    expect(element).to.have.selectionCount(10);
+                });
+
+                describe('when first element is focused', function () {
+                    beforeEach(function () {
+                        model.focusItem(0);
+                    });
+
+                    it('selects the focused element on up-arrow', function () {
+                        specHelper.arrowUp($('ul', element));
+                        expect($('#item0')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
+                });
+
+                describe('when last element is focused', function () {
+                    beforeEach(function () {
+                        model.focusItem(9);
+                    });
+
+                    it('selects the focused element on down-arrow', function () {
+                        specHelper.arrowDown($('ul', element));
+                        expect($('#item9')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
+                });
+
+                describe('when the selection is set manually', function () {
+
+                    it('selects one item manually', function () {
+                        model.selection([model.items()[3]]);
+
+                        expect($('#item3')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
+
+                    it('selects multiple items manually', function () {
+                        model.selection([model.items()[3], model.items()[9]]);
+
+                        expect(element).to.have.selectionCount(2);
+                        expect($('#item3')).to.have.cssClass('selected');
+                        expect($('#item9')).to.have.cssClass('selected');
+                    });
+
+                });
+            });
+
+            describe('with selected items', function () {
+                beforeEach(function () {
+                    model.select(7, 4, 2);
+                    model.focusItem(2);
+                    model.anchorItem(2);
+                });
+
+                it('expands the selection with ctrl-click', function () {
+                    specHelper.click($('#item3'), { ctrlKey: true });
+                    expect(element).to.have.selectionCount(4);
+                    [2, 3, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('deselected selected items with ctrl-click', function () {
+                    specHelper.click($('#item4'), { ctrlKey: true });
+                    expect(element).to.have.selectionCount(2);
+                    [2, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('expands the selection on space', function () {
+                    model.focusItem(6);
+                    specHelper.space($('ul', element));
+                    [2, 4, 6, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                    expect(element).to.have.selectionCount(4);
+                });
+
+                it('ignores ctrl key on space', function () {
+                    model.focusItem(6);
+                    specHelper.space($('ul', element), { ctrlKey: true });
+                    [2, 4, 6, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                    expect(element).to.have.selectionCount(4);
+                });
+
+                it('ignores shift key on space', function () {
+                    model.focusItem(6);
+                    specHelper.space($('ul', element), { shiftKey: true });
+                    [2, 4, 6, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                    expect(element).to.have.selectionCount(4);
+                });
+
+                it('maintains the selection of non-focused, but selected, elements on space', function () {
+                    specHelper.space($('ul', element));
+                    [4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                    expect(element).to.have.selectionCount(2);
+                });
+
+                it('expands the selection with shift-click', function () {
+                    specHelper.click($('#item5'), { shiftKey: true });
+                    expect(element).to.have.selectionCount(4);
+                    [2, 3, 4, 5].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('expands the selection downward on shift-down-arrow', function () {
+                    specHelper.arrowDown($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(2);
+                    [2, 3].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('expands the selection further downward on successive shift-down-arrow', function () {
+                    specHelper.arrowDown($('ul', element), { shiftKey: true });
+                    specHelper.arrowDown($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [2, 3, 4].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('expands the selection upward on shift-up-arrow', function () {
+                    specHelper.arrowUp($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(2);
+                    [1, 2].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('expands the selection further upward on successive shift-up-arrow', function () {
+                    specHelper.arrowUp($('ul', element), { shiftKey: true });
+                    specHelper.arrowUp($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [0, 1, 2].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('does not move the selection anchor on successive shift-up/down-arrow', function () {
+                    specHelper.arrowDown($('ul', element), { shiftKey: true });
+                    specHelper.arrowDown($('ul', element), { shiftKey: true });
+                    specHelper.arrowUp($('ul', element), { shiftKey: true });
+                    specHelper.arrowDown($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [2, 3, 4].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('maintains the selection on ctrl-down-arrow', function () {
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('maintains the selection on successive ctrl-down-arrow', function () {
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('moves the selection anchor downwards on ctrl-down-arrow', function () {
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    specHelper.arrowDown($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(2);
+                    [3, 4].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('moves the selection anchor further downward on successive ctrl-down-arrow', function () {
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    specHelper.arrowDown($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(2);
+                    [4, 5].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('maintains the selection on ctrl-up-arrow', function () {
+                    specHelper.arrowUp($('ul', element), { ctrlKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('maintains the selection on successive ctrl-up-arrow', function () {
+                    specHelper.arrowUp($('ul', element), { ctrlKey: true });
+                    specHelper.arrowUp($('ul', element), { ctrlKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('moves the selection anchor upward on ctrl-up-arrow', function () {
+                    specHelper.arrowUp($('ul', element), { ctrlKey: true });
+
+                    expect(model.anchor().id).to.be('item1');
+                });
+
+                it('moves the selection anchor further upward on successive ctrl-up-arrow', function () {
+                    specHelper.arrowUp($('ul', element), { ctrlKey: true });
+                    specHelper.arrowUp($('ul', element), { ctrlKey: true });
+                    expect(model.anchor().id).to.be('item0');
+                });
+
+                it('moves the selection anchor on successive ctrl-up/down-arrow', function () {
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    specHelper.arrowUp($('ul', element), { ctrlKey: true });
+                    expect(model.anchor().id).to.be('item3');
+                });
+
+                it('maintains selection on successive ctrl-up/down-arrow', function () {
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    specHelper.arrowUp($('ul', element), { ctrlKey: true });
+
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                    expect(element).to.have.selectionCount(3);
+                });
+
+                it('selects all items from anchor to top on shift-home', function () {
+                    specHelper.home($('ul', element), { shiftKey: true });
+
+                    expect(element).to.have.selectionCount(3);
+                    [0, 1, 2].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('selects all items from anchor to bottom on shift-end', function () {
+                    specHelper.end($('ul', element), { shiftKey: true });
+
+                    expect(element).to.have.selectionCount(8);
+                    [2, 3, 4, 5, 6, 7, 8, 9].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('moves the selection anchor to top on ctrl-home', function () {
+                    specHelper.home($('ul', element), { ctrlKey: true });
+                    expect(model.anchor().id).to.be('item0');
+
+                    expect(element).to.have.selectionCount(3);
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('moves the selection anchor to bottom on ctrl-end', function () {
+                    specHelper.end($('ul', element), { ctrlKey: true });
+                    expect(model.anchor().id).to.be('item9');
+
+                    expect(element).to.have.selectionCount(3);
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('expands selection with range from anchor to top on ctrl-shift-home', function () {
+                    specHelper.home($('ul', element), { ctrlKey: true, shiftKey: true });
+
+                    expect(element).to.have.selectionCount(5);
+                    [0, 1, 2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('expands selection with range from anchor to bottom on ctrl-shift-end', function () {
+                    model.focusItem(6);
+                    model.anchorItem(6);
+                    specHelper.end($('ul', element), { ctrlKey: true, shiftKey: true });
+
+                    expect(element).to.have.selectionCount(6);
+                    [2, 4, 6, 7, 8, 9].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('removes the selection and selects next element on down-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowDown($('ul', element));
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item4')).to.have.cssClass('selected');
+                });
+
+                it('removes the selection and selects previous element on up-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowUp($('ul', element));
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item2')).to.have.cssClass('selected');
+                });
+
+                it('removes the selection and selects clicked item on mouse click', function () {
+                    model.focusItem(3);
+                    specHelper.click($('#item8'));
+                    expect(element).to.have.selectionCount(1);
+                    expect($('#item8')).to.have.cssClass('selected');
+                });
+
+                it('keeps its selection count after one of the unselected items is removed from the observable array', function () {
+                    model.items.remove(model.getItem(6));
+                    expect(element).to.have.selectionCount(3);
+                });
+
+                it('has its selection count decremented after one of selected items is removed from the observable array', function () {
+                    model.items.remove(model.getItem(7));
+                    expect(element).to.have.selectionCount(2);
+                });
+
+                it('has its selection count decremented after the focused and selected item is removed from the observable array', function () {
+                    model.items.remove(model.getItem(2));
+                    expect(element).to.have.selectionCount(2);
+                });
+
+                it('focuses the item at the same index after the focused item is removed from the observable array', function () {
+                    model.items.remove(model.getItem(2));
+                    expect(model.focused()).to.be(model.getItem(2));
+                    expect(model.focused().id).to.be('item3');
+                });
+
+                it('focuses the new last item if the last item was focused and removed from the observable array', function () {
+                    model.focusItem(9);
+                    model.items.remove(model.getItem(9));
+                    expect(model.focused()).to.be(model.getItem(8));
+                    expect(model.focused().id).to.be('item8');
+                });
+
+                it('has its anchor observable set to null after the anchor item is removed from the observable array', function () {
+                    model.items.remove(model.getItem(2));
+                    expect(model.anchor()).to.not.be.ok();
+                });
+
+                it('is possible to cancel the selection event if the item is alreay selected', function () {
+                    $('#item4').one('mouseup', function (e) {
+                        e.stopPropagation();
+                    });
+
+                    var focused = model.focused();
+                    var anchor = model.anchor();
+
+                    specHelper.click($('#item4'));
+                    expect(focused).to.be(model.focused());
+                    expect(anchor).to.be(model.anchor());
+                    expect(element).to.have.selectionCount(3);
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                describe('when the selection is set manually', function () {
+
+                    it('selects one item manually', function () {
+                        model.selection([model.items()[3]]);
+
+                        expect($('#item3')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
+
+                    it('selects multiple items manually', function () {
+                        model.selection([model.items()[3], model.items()[9]]);
+
+                        expect(element).to.have.selectionCount(2);
+                        expect($('#item3')).to.have.cssClass('selected');
+                        expect($('#item9')).to.have.cssClass('selected');
+                    });
+                });
+
+                describe('when the content of foreach is altered', function () {
+
+                    it('keeps items selected when they are still in the foreach', function () {
+                        model.items(model.items().slice(2, 8));
+
+                        expect(element).to.have.selectionCount(3);
+                        [2, 4, 7].forEach(function (index) {
+                            expect($('#item' + index)).to.have.cssClass('selected');
+                        });
+                        expect(model.selection().length).to.be(3);
+                    });
+
+                    it('removes items from selection when they are removed from foreach', function () {
+                        model.items(model.items().slice(5));
+
+                        expect(element).to.have.selectionCount(1);
+                        expect($('#item7')).to.have.cssClass('selected');
+                        expect(model.selection().length).to.be(1);
+                    });
+                });
+
+                describe('clicking on an element that have the toggleClass', function () {
+                    describe('and the item is selected', function () {
+                        beforeEach(function () {
+                            specHelper.click($('#item7 .checkbox'));
+                        });
+
+                        it('unselects the item', function () {
+                            expect($('#item7')).not.to.have.cssClass('selected');
+                        });
+
+                        it('does not change the selection of the other items', function () {
+                            expect(element).to.have.selectionCount(2);
+                            expect($('#item2')).to.have.cssClass('selected');
+                            expect($('#item4')).to.have.cssClass('selected');
+                        });
+
+                        it('sets the item as the focus', function () {
+                            expect(model.focused().id).to.be('item7');
+                        });
+
+                        it('sets the item as the anchor', function () {
+                            expect(model.anchor().id).to.be('item7');
+                        });
+                    });
+
+                    describe('and the item is not selected', function () {
+                        beforeEach(function () {
+                            specHelper.click($('#item3 .checkbox'));
+                        });
+
+                        it('selects the item in addition to the current selection', function () {
+                            expect(element).to.have.selectionCount(4);
+                            expect($('#item3')).to.have.cssClass('selected');
+                            expect($('#item2')).to.have.cssClass('selected');
+                            expect($('#item4')).to.have.cssClass('selected');
+                            expect($('#item7')).to.have.cssClass('selected');
+                        });
+
+                        it('sets the item as the focus', function () {
+                            expect(model.focused().id).to.be('item3');
+                        });
+
+                        it('sets the item as the anchor', function () {
+                            expect(model.anchor().id).to.be('item3');
+                        });
+                    });
+                });
+            });
+
+            describe('clicking on an element that have the toggleClass', function () {
+                beforeEach(function () {
+                    specHelper.click($('#item7 .checkbox'));
+                });
+
+                it('selects the item', function () {
+                    expect($('#item7')).to.have.cssClass('selected');
+                });
+
+                it('sets the item as the focus', function () {
+                    expect(model.focused().id).to.be('item7');
+                });
+
+                it('sets the item as the anchor', function () {
+                    expect(model.anchor().id).to.be('item7');
+                });
+            });
+
+            describe('clicking on an element inside an element that have the toggleClass', function () {
+                beforeEach(function () {
+                    specHelper.click($('#item7 .inside-checkbox'));
+                });
+
+                it('selects the item', function () {
+                    expect($('#item7')).to.have.cssClass('selected');
+                });
+
+                it('sets the item as the focus', function () {
+                    expect(model.focused().id).to.be('item7');
+                });
+
+                it('sets the item as the anchor', function () {
+                    expect(model.anchor().id).to.be('item7');
+                });
+            });
+
+            describe('clicking on elements that have the toggleClass', function () {
+                it('sets the item as the focus', function () {
+                    specHelper.click($('#item7 .checkbox'));
+                    expect(model.focused().id).to.be('item7');
+                });
+
+                it('sets the item as the anchor', function () {
+                    specHelper.click($('#item7 .checkbox'));
+                    expect(model.anchor().id).to.be('item7');
+                });
+            });
+
+            it('updates the DOM when the selection data is changed', function () {
+                model.selection([2, 3, 4, 7].map(function (index) {
+                    return model.items()[index];
+                }));
+
                 expect(element).to.have.selectionCount(4);
                 [2, 3, 4, 7].forEach(function (index) {
                     expect($('#item' + index)).to.have.cssClass('selected');
                 });
             });
 
-            it('deselected selected items with ctrl-click', function () {
-                click($('#item4'), { ctrlKey: true });
-                expect(element).to.have.selectionCount(2);
-                [2, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
+            it('updates the DOM when the focus changes', function () {
+                model.focused(model.items()[4]);
+                expect(element).to.have.selectionCount(0);
+                expect($('#item4')).to.have.cssClass('focused');
             });
 
-            it('expands the selection on space', function () {
-                model.focusItem(6);
-                space($('ul', element));
-                [2, 4, 6, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-                expect(element).to.have.selectionCount(4);
+            it('updates selected field of items when the selection data is changed', function () {
+                model.selection([2, 3, 4, 7].map(function (index) {
+                    return model.items()[index];
+                }));
+
+                var selectionCount = model.items().reduce(function (result, item) {
+                    return result + item.selected();
+                }, 0);
+                expect(selectionCount).to.be(4);
             });
 
-            it('ignores ctrl key on space', function () {
-                model.focusItem(6);
-                space($('ul', element), { ctrlKey: true });
-                [2, 4, 6, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-                expect(element).to.have.selectionCount(4);
+            it('updates focused field of the items when the focus changes', function () {
+                model.focused(model.items()[4]);
+                var focusCount = model.items().reduce(function (result, item) {
+                    return result + item.focused();
+                }, 0);
+                expect(focusCount).to.be(1);
+                expect(model.items()[4].focused()).to.be.ok();
+            });
+        });
+
+        describe('in multiple selection mode, horizontal', function () {
+            beforeEach(function () {
+                element = specHelper.createTestElement(
+                    'foreach: items, selection: { selection: selection, focused: focused, anchor: anchor, direction: "horizontal" }',
+                    'attr: { id: id }, css: { selected: selected, focused: focused }'
+                );
+                ko.applyBindings(model, element);
             });
 
-            it('ignores shift key on space', function () {
-                model.focusItem(6);
-                space($('ul', element), { shiftKey: true });
-                [2, 4, 6, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-                expect(element).to.have.selectionCount(4);
-            });
-
-            it('maintains the selection of non-focused, but selected, elements on space', function () {
-                space($('ul', element));
-                [4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-                expect(element).to.have.selectionCount(2);
-            });
-
-            it('expands the selection with shift-click', function () {
-                click($('#item5'), { shiftKey: true });
-                expect(element).to.have.selectionCount(4);
-                [2, 3, 4, 5].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('expands the selection downward on shift-down-arrow', function () {
-                arrowDown($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(2);
-                [2, 3].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('expands the selection further downward on successive shift-down-arrow', function () {
-                arrowDown($('ul', element), { shiftKey: true });
-                arrowDown($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 3, 4].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('expands the selection upward on shift-up-arrow', function () {
-                arrowUp($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(2);
-                [1, 2].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('expands the selection further upward on successive shift-up-arrow', function () {
-                arrowUp($('ul', element), { shiftKey: true });
-                arrowUp($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(3);
-                [0, 1, 2].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('does not move the selection anchor on successive shift-up/down-arrow', function () {
-                arrowDown($('ul', element), { shiftKey: true });
-                arrowDown($('ul', element), { shiftKey: true });
-                arrowUp($('ul', element), { shiftKey: true });
-                arrowDown($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 3, 4].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('maintains the selection on ctrl-down-arrow', function () {
-                arrowDown($('ul', element), { ctrlKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('maintains the selection on successive ctrl-down-arrow', function () {
-                arrowDown($('ul', element), { ctrlKey: true });
-                arrowDown($('ul', element), { ctrlKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('moves the selection anchor downwards on ctrl-down-arrow', function () {
-                arrowDown($('ul', element), { ctrlKey: true });
-                arrowDown($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(2);
-                [3, 4].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('moves the selection anchor further downward on successive ctrl-down-arrow', function () {
-                arrowDown($('ul', element), { ctrlKey: true });
-                arrowDown($('ul', element), { ctrlKey: true });
-                arrowDown($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(2);
-                [4, 5].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('maintains the selection on ctrl-up-arrow', function () {
-                arrowUp($('ul', element), { ctrlKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('maintains the selection on successive ctrl-up-arrow', function () {
-                arrowUp($('ul', element), { ctrlKey: true });
-                arrowUp($('ul', element), { ctrlKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('moves the selection anchor upward on ctrl-up-arrow', function () {
-                arrowUp($('ul', element), { ctrlKey: true });
-
-                expect(model.anchor().id).to.be('item1');
-            });
-
-            it('moves the selection anchor further upward on successive ctrl-up-arrow', function () {
-                arrowUp($('ul', element), { ctrlKey: true });
-                arrowUp($('ul', element), { ctrlKey: true });
-                expect(model.anchor().id).to.be('item0');
-            });
-
-            it('moves the selection anchor on successive ctrl-up/down-arrow', function () {
-                arrowDown($('ul', element), { ctrlKey: true });
-                arrowDown($('ul', element), { ctrlKey: true });
-                arrowUp($('ul', element), { ctrlKey: true });
-                expect(model.anchor().id).to.be('item3');
-            });
-
-            it('maintains selection on successive ctrl-up/down-arrow', function () {
-                arrowDown($('ul', element), { ctrlKey: true });
-                arrowDown($('ul', element), { ctrlKey: true });
-                arrowUp($('ul', element), { ctrlKey: true });
-
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-                expect(element).to.have.selectionCount(3);
-            });
-
-            it('selects all items from anchor to top on shift-home', function () {
-                home($('ul', element), { shiftKey: true });
-
-                expect(element).to.have.selectionCount(3);
-                [0, 1, 2].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('selects all items from anchor to bottom on shift-end', function () {
-                end($('ul', element), { shiftKey: true });
-
-                expect(element).to.have.selectionCount(8);
-                [2, 3, 4, 5, 6, 7, 8, 9].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('moves the selection anchor to top on ctrl-home', function () {
-                home($('ul', element), { ctrlKey: true });
-                expect(model.anchor().id).to.be('item0');
-
-                expect(element).to.have.selectionCount(3);
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('moves the selection anchor to bottom on ctrl-end', function () {
-                end($('ul', element), { ctrlKey: true });
-                expect(model.anchor().id).to.be('item9');
-
-                expect(element).to.have.selectionCount(3);
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('expands selection with range from anchor to top on ctrl-shift-home', function () {
-                home($('ul', element), { ctrlKey: true, shiftKey: true });
-
-                expect(element).to.have.selectionCount(5);
-                [0, 1, 2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('expands selection with range from anchor to bottom on ctrl-shift-end', function () {
-                model.focusItem(6);
-                model.anchorItem(6);
-                end($('ul', element), { ctrlKey: true, shiftKey: true });
-
-                expect(element).to.have.selectionCount(6);
-                [2, 4, 6, 7, 8, 9].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('removes the selection and selects next element on down-arrow', function () {
-                model.focusItem(3);
-                arrowDown($('ul', element));
-                expect(element).to.have.selectionCount(1);
-                expect($('#item4')).to.have.cssClass('selected');
-            });
-
-            it('removes the selection and selects previous element on up-arrow', function () {
-                model.focusItem(3);
-                arrowUp($('ul', element));
-                expect(element).to.have.selectionCount(1);
-                expect($('#item2')).to.have.cssClass('selected');
-            });
-
-            it('removes the selection and selects clicked item on mouse click', function () {
-                model.focusItem(3);
-                click($('#item8'));
-                expect(element).to.have.selectionCount(1);
-                expect($('#item8')).to.have.cssClass('selected');
-            });
-
-            it('keeps its selection count after one of the unselected items is removed from the observable array', function () {
-                model.items.remove(model.getItem(6));
-                expect(element).to.have.selectionCount(3);
-            });
-
-            it('has its selection count decremented after one of selected items is removed from the observable array', function () {
-                model.items.remove(model.getItem(7));
-                expect(element).to.have.selectionCount(2);
-            });
-
-            it('has its selection count decremented after the focused and selected item is removed from the observable array', function () {
-                model.items.remove(model.getItem(2));
-                expect(element).to.have.selectionCount(2);
-            });
-
-            it('focuses the item at the same index after the focused item is removed from the observable array', function () {
-                model.items.remove(model.getItem(2));
-                expect(model.focused()).to.be(model.getItem(2));
-                expect(model.focused().id).to.be('item3');
-            });
-
-            it('focuses the new last item if the last item was focused and removed from the observable array', function () {
-                model.focusItem(9);
-                model.items.remove(model.getItem(9));
-                expect(model.focused()).to.be(model.getItem(8));
-                expect(model.focused().id).to.be('item8');
-            });
-
-            it('has its anchor observable set to null after the anchor item is removed from the observable array', function () {
-                model.items.remove(model.getItem(2));
-                expect(model.anchor()).to.not.be.ok();
-            });
-
-            it('is possible to cancel the selection event if the item is alreay selected', function () {
-                $('#item4').one('mouseup', function (e) {
-                    e.stopPropagation();
-                });
-
-                var focused = model.focused();
-                var anchor = model.anchor();
-
-                click($('#item4'));
-                expect(focused).to.be(model.focused());
-                expect(anchor).to.be(model.anchor());
-                expect(element).to.have.selectionCount(3);
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            describe('when the selection is set manually', function () {
-
-                it('selects one item manually', function () {
-                    model.selection([model.items()[3]]);
-
-                    expect($('#item3')).to.have.cssClass('selected');
+            describe('with no selection', function () {
+                it('selects the element after the focused element on right-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowRight($('ul', element));
+                    expect($('#item4')).to.have.cssClass('selected');
                     expect(element).to.have.selectionCount(1);
                 });
 
-                it('selects multiple items manually', function () {
-                    model.selection([model.items()[3], model.items()[9]]);
+                it('selects the element before the focused element on left-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowLeft($('ul', element));
+                    expect($('#item2')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(1);
+                });
 
-                    expect(element).to.have.selectionCount(2);
+                it('selects and focuses the element after the focused element on shift-right-arrow', function () {
+                    model.focusItem(3);
+                    model.anchorItem(3);
+                    specHelper.arrowRight($('ul', element), { shiftKey: true });
                     expect($('#item3')).to.have.cssClass('selected');
-                    expect($('#item9')).to.have.cssClass('selected');
+                    expect($('#item4')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(2);
+                });
+
+                it('selects and focuses the element before the focused element on shift-left-arrow', function () {
+                    model.focusItem(3);
+                    model.anchorItem(3);
+                    specHelper.arrowLeft($('ul', element), { shiftKey: true });
+                    expect($('#item3')).to.have.cssClass('selected');
+                    expect($('#item2')).to.have.cssClass('selected');
+                    expect(element).to.have.selectionCount(2);
+                });
+
+                describe('when first element is focused', function () {
+                    beforeEach(function () {
+                        model.focusItem(0);
+                    });
+
+                    it('selects the focused element on left-arrow', function () {
+                        specHelper.arrowLeft($('ul', element));
+                        expect($('#item0')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
+                });
+
+                describe('when last element is focused', function () {
+                    beforeEach(function () {
+                        model.focusItem(9);
+                    });
+
+                    it('selects the focused element on right-arrow', function () {
+                        specHelper.arrowRight($('ul', element));
+                        expect($('#item9')).to.have.cssClass('selected');
+                        expect(element).to.have.selectionCount(1);
+                    });
                 });
             });
 
-            describe('when the content of foreach is altered', function () {
+            describe('with selected items', function () {
+                beforeEach(function () {
+                    model.select(7, 4, 2);
+                    model.focusItem(2);
+                    model.anchorItem(2);
+                });
 
-                it('keeps items selected when they are still in the foreach', function () {
-                    model.items(model.items().slice(2, 8));
+                it('expands the selection downward on shift-right-arrow', function () {
+                    specHelper.arrowRight($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(2);
+                    [2, 3].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
 
+                it('expands the selection further downward on successive shift-right-arrow', function () {
+                    specHelper.arrowRight($('ul', element), { shiftKey: true });
+                    specHelper.arrowRight($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [2, 3, 4].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('expands the selection upward on shift-left-arrow', function () {
+                    specHelper.arrowLeft($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(2);
+                    [1, 2].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('expands the selection further upward on successive shift-left-arrow', function () {
+                    specHelper.arrowLeft($('ul', element), { shiftKey: true });
+                    specHelper.arrowLeft($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [0, 1, 2].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('does not move the selection anchor on successive shift-left/right-arrow', function () {
+                    specHelper.arrowRight($('ul', element), { shiftKey: true });
+                    specHelper.arrowRight($('ul', element), { shiftKey: true });
+                    specHelper.arrowLeft($('ul', element), { shiftKey: true });
+                    specHelper.arrowRight($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [2, 3, 4].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('maintains the selection on ctrl-right-arrow', function () {
+                    specHelper.arrowRight($('ul', element), { ctrlKey: true });
                     expect(element).to.have.selectionCount(3);
                     [2, 4, 7].forEach(function (index) {
                         expect($('#item' + index)).to.have.cssClass('selected');
                     });
-                    expect(model.selection().length).to.be(3);
                 });
 
-                it('removes items from selection when they are removed from foreach', function () {
-                    model.items(model.items().slice(5));
+                it('maintains the selection on successive ctrl-right-arrow', function () {
+                    specHelper.arrowRight($('ul', element), { ctrlKey: true });
+                    specHelper.arrowRight($('ul', element), { ctrlKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
 
+                it('moves the selection anchor downwards on ctrl-right-arrow', function () {
+                    specHelper.arrowRight($('ul', element), { ctrlKey: true });
+                    specHelper.arrowRight($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(2);
+                    [3, 4].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('moves the selection anchor further downward on successive ctrl-right-arrow', function () {
+                    specHelper.arrowRight($('ul', element), { ctrlKey: true });
+                    specHelper.arrowRight($('ul', element), { ctrlKey: true });
+                    specHelper.arrowRight($('ul', element), { shiftKey: true });
+                    expect(element).to.have.selectionCount(2);
+                    [4, 5].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('maintains the selection on ctrl-left-arrow', function () {
+                    specHelper.arrowLeft($('ul', element), { ctrlKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('maintains the selection on successive ctrl-left-arrow', function () {
+                    specHelper.arrowLeft($('ul', element), { ctrlKey: true });
+                    specHelper.arrowLeft($('ul', element), { ctrlKey: true });
+                    expect(element).to.have.selectionCount(3);
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                });
+
+                it('moves the selection anchor upward on ctrl-left-arrow', function () {
+                    specHelper.arrowLeft($('ul', element), { ctrlKey: true });
+
+                    expect(model.anchor().id).to.be('item1');
+                });
+
+                it('moves the selection anchor further upward on successive ctrl-left-arrow', function () {
+                    specHelper.arrowLeft($('ul', element), { ctrlKey: true });
+                    specHelper.arrowLeft($('ul', element), { ctrlKey: true });
+                    expect(model.anchor().id).to.be('item0');
+                });
+
+                it('moves the selection anchor on successive ctrl-left/right-arrow', function () {
+                    specHelper.arrowRight($('ul', element), { ctrlKey: true });
+                    specHelper.arrowRight($('ul', element), { ctrlKey: true });
+                    specHelper.arrowLeft($('ul', element), { ctrlKey: true });
+                    expect(model.anchor().id).to.be('item3');
+                });
+
+                it('maintains selection on successive ctrl-left/right-arrow', function () {
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    specHelper.arrowDown($('ul', element), { ctrlKey: true });
+                    specHelper.arrowLeft($('ul', element), { ctrlKey: true });
+
+                    [2, 4, 7].forEach(function (index) {
+                        expect($('#item' + index)).to.have.cssClass('selected');
+                    });
+                    expect(element).to.have.selectionCount(3);
+                });
+
+                it('removes the selection and selects next element on right-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowRight($('ul', element));
                     expect(element).to.have.selectionCount(1);
-                    expect($('#item7')).to.have.cssClass('selected');
-                    expect(model.selection().length).to.be(1);
-                });
-            });
-
-            describe('clicking on an element that have the toggleClass', function () {
-                describe('and the item is selected', function () {
-                    beforeEach(function () {
-                        click($('#item7 .checkbox'));
-                    });
-
-                    it('unselects the item', function () {
-                        expect($('#item7')).not.to.have.cssClass('selected');
-                    });
-
-                    it('does not change the selection of the other items', function () {
-                        expect(element).to.have.selectionCount(2);
-                        expect($('#item2')).to.have.cssClass('selected');
-                        expect($('#item4')).to.have.cssClass('selected');
-                    });
-
-                    it('sets the item as the focus', function () {
-                        expect(model.focused().id).to.be('item7');
-                    });
-
-                    it('sets the item as the anchor', function () {
-                        expect(model.anchor().id).to.be('item7');
-                    });
+                    expect($('#item4')).to.have.cssClass('selected');
                 });
 
-                describe('and the item is not selected', function () {
-                    beforeEach(function () {
-                        click($('#item3 .checkbox'));
-                    });
-
-                    it('selects the item in addition to the current selection', function () {
-                        expect(element).to.have.selectionCount(4);
-                        expect($('#item3')).to.have.cssClass('selected');
-                        expect($('#item2')).to.have.cssClass('selected');
-                        expect($('#item4')).to.have.cssClass('selected');
-                        expect($('#item7')).to.have.cssClass('selected');
-                    });
-
-                    it('sets the item as the focus', function () {
-                        expect(model.focused().id).to.be('item3');
-                    });
-
-                    it('sets the item as the anchor', function () {
-                        expect(model.anchor().id).to.be('item3');
-                    });
-                });
-            });
-        });
-
-        describe('clicking on an element that have the toggleClass', function () {
-            beforeEach(function () {
-                click($('#item7 .checkbox'));
-            });
-
-            it('selects the item', function () {
-                expect($('#item7')).to.have.cssClass('selected');
-            });
-
-            it('sets the item as the focus', function () {
-                expect(model.focused().id).to.be('item7');
-            });
-
-            it('sets the item as the anchor', function () {
-                expect(model.anchor().id).to.be('item7');
-            });
-        });
-
-        describe('clicking on an element inside an element that have the toggleClass', function () {
-            beforeEach(function () {
-                click($('#item7 .inside-checkbox'));
-            });
-
-            it('selects the item', function () {
-                expect($('#item7')).to.have.cssClass('selected');
-            });
-
-            it('sets the item as the focus', function () {
-                expect(model.focused().id).to.be('item7');
-            });
-
-            it('sets the item as the anchor', function () {
-                expect(model.anchor().id).to.be('item7');
-            });
-        });
-
-        describe('clicking on elements that have the toggleClass', function () {
-            it('sets the item as the focus', function () {
-                click($('#item7 .checkbox'));
-                expect(model.focused().id).to.be('item7');
-            });
-
-            it('sets the item as the anchor', function () {
-                click($('#item7 .checkbox'));
-                expect(model.anchor().id).to.be('item7');
-            });
-        });
-
-        it('updates the DOM when the selection data is changed', function () {
-            model.selection([2, 3, 4, 7].map(function (index) {
-                return model.items()[index];
-            }));
-
-            expect(element).to.have.selectionCount(4);
-            [2, 3, 4, 7].forEach(function (index) {
-                expect($('#item' + index)).to.have.cssClass('selected');
-            });
-        });
-
-        it('updates the DOM when the focus changes', function () {
-            model.focused(model.items()[4]);
-            expect(element).to.have.selectionCount(0);
-            expect($('#item4')).to.have.cssClass('focused');
-        });
-
-        it('updates selected field of items when the selection data is changed', function () {
-            model.selection([2, 3, 4, 7].map(function (index) {
-                return model.items()[index];
-            }));
-
-            var selectionCount = model.items().reduce(function (result, item) {
-                return result + item.selected();
-            }, 0);
-            expect(selectionCount).to.be(4);
-        });
-
-        it('updates focused field of the items when the focus changes', function () {
-            model.focused(model.items()[4]);
-            var focusCount = model.items().reduce(function (result, item) {
-                return result + item.focused();
-            }, 0);
-            expect(focusCount).to.be(1);
-            expect(model.items()[4].focused()).to.be.ok();
-        });
-    });
-
-    describe('in multiple selection mode, horizontal', function () {
-        beforeEach(function () {
-            element = createTestElement(
-                'foreach: items, selection: { selection: selection, focused: focused, anchor: anchor, direction: "horizontal" }',
-                'attr: { id: id }, css: { selected: selected, focused: focused }'
-            );
-            ko.applyBindings(model, element);
-        });
-
-        describe('with no selection', function () {
-            it('selects the element after the focused element on right-arrow', function () {
-                model.focusItem(3);
-                arrowRight($('ul', element));
-                expect($('#item4')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects the element before the focused element on left-arrow', function () {
-                model.focusItem(3);
-                arrowLeft($('ul', element));
-                expect($('#item2')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(1);
-            });
-
-            it('selects and focuses the element after the focused element on shift-right-arrow', function () {
-                model.focusItem(3);
-                model.anchorItem(3);
-                arrowRight($('ul', element), { shiftKey: true });
-                expect($('#item3')).to.have.cssClass('selected');
-                expect($('#item4')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(2);
-            });
-
-            it('selects and focuses the element before the focused element on shift-left-arrow', function () {
-                model.focusItem(3);
-                model.anchorItem(3);
-                arrowLeft($('ul', element), { shiftKey: true });
-                expect($('#item3')).to.have.cssClass('selected');
-                expect($('#item2')).to.have.cssClass('selected');
-                expect(element).to.have.selectionCount(2);
-            });
-
-            describe('when first element is focused', function () {
-                beforeEach(function () {
-                    model.focusItem(0);
-                });
-
-                it('selects the focused element on left-arrow', function () {
-                    arrowLeft($('ul', element));
-                    expect($('#item0')).to.have.cssClass('selected');
+                it('removes the selection and selects previous element on left-arrow', function () {
+                    model.focusItem(3);
+                    specHelper.arrowLeft($('ul', element));
                     expect(element).to.have.selectionCount(1);
-                });
-            });
-
-            describe('when last element is focused', function () {
-                beforeEach(function () {
-                    model.focusItem(9);
-                });
-
-                it('selects the focused element on right-arrow', function () {
-                    arrowRight($('ul', element));
-                    expect($('#item9')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item2')).to.have.cssClass('selected');
                 });
             });
         });
 
-        describe('with selected items', function () {
+        describe('when data is given as a argument', function () {
+            var items;
             beforeEach(function () {
-                model.select(7, 4, 2);
-                model.focusItem(2);
-                model.anchorItem(2);
-            });
+                element = specHelper.createTestElement(
+                    'foreach: items, selection: { data: allItems, selection: selection, focused: focused, anchor: anchor }',
+                    'attr: { id: id }, css: { selected: selected, focused: focused }'
+                );
 
-            it('expands the selection downward on shift-right-arrow', function () {
-                arrowRight($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(2);
-                [2, 3].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('expands the selection further downward on successive shift-right-arrow', function () {
-                arrowRight($('ul', element), { shiftKey: true });
-                arrowRight($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 3, 4].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('expands the selection upward on shift-left-arrow', function () {
-                arrowLeft($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(2);
-                [1, 2].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('expands the selection further upward on successive shift-left-arrow', function () {
-                arrowLeft($('ul', element), { shiftKey: true });
-                arrowLeft($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(3);
-                [0, 1, 2].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('does not move the selection anchor on successive shift-left/right-arrow', function () {
-                arrowRight($('ul', element), { shiftKey: true });
-                arrowRight($('ul', element), { shiftKey: true });
-                arrowLeft($('ul', element), { shiftKey: true });
-                arrowRight($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 3, 4].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('maintains the selection on ctrl-right-arrow', function () {
-                arrowRight($('ul', element), { ctrlKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('maintains the selection on successive ctrl-right-arrow', function () {
-                arrowRight($('ul', element), { ctrlKey: true });
-                arrowRight($('ul', element), { ctrlKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('moves the selection anchor downwards on ctrl-right-arrow', function () {
-                arrowRight($('ul', element), { ctrlKey: true });
-                arrowRight($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(2);
-                [3, 4].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('moves the selection anchor further downward on successive ctrl-right-arrow', function () {
-                arrowRight($('ul', element), { ctrlKey: true });
-                arrowRight($('ul', element), { ctrlKey: true });
-                arrowRight($('ul', element), { shiftKey: true });
-                expect(element).to.have.selectionCount(2);
-                [4, 5].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('maintains the selection on ctrl-left-arrow', function () {
-                arrowLeft($('ul', element), { ctrlKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('maintains the selection on successive ctrl-left-arrow', function () {
-                arrowLeft($('ul', element), { ctrlKey: true });
-                arrowLeft($('ul', element), { ctrlKey: true });
-                expect(element).to.have.selectionCount(3);
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-            });
-
-            it('moves the selection anchor upward on ctrl-left-arrow', function () {
-                arrowLeft($('ul', element), { ctrlKey: true });
-
-                expect(model.anchor().id).to.be('item1');
-            });
-
-            it('moves the selection anchor further upward on successive ctrl-left-arrow', function () {
-                arrowLeft($('ul', element), { ctrlKey: true });
-                arrowLeft($('ul', element), { ctrlKey: true });
-                expect(model.anchor().id).to.be('item0');
-            });
-
-            it('moves the selection anchor on successive ctrl-left/right-arrow', function () {
-                arrowRight($('ul', element), { ctrlKey: true });
-                arrowRight($('ul', element), { ctrlKey: true });
-                arrowLeft($('ul', element), { ctrlKey: true });
-                expect(model.anchor().id).to.be('item3');
-            });
-
-            it('maintains selection on successive ctrl-left/right-arrow', function () {
-                arrowDown($('ul', element), { ctrlKey: true });
-                arrowDown($('ul', element), { ctrlKey: true });
-                arrowLeft($('ul', element), { ctrlKey: true });
-
-                [2, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
-                });
-                expect(element).to.have.selectionCount(3);
-            });
-
-            it('removes the selection and selects next element on right-arrow', function () {
-                model.focusItem(3);
-                arrowRight($('ul', element));
-                expect(element).to.have.selectionCount(1);
-                expect($('#item4')).to.have.cssClass('selected');
-            });
-
-            it('removes the selection and selects previous element on left-arrow', function () {
-                model.focusItem(3);
-                arrowLeft($('ul', element));
-                expect(element).to.have.selectionCount(1);
-                expect($('#item2')).to.have.cssClass('selected');
-            });
-        });
-    });
-
-    describe('when data is given as a argument', function () {
-        var items;
-        beforeEach(function () {
-            element = createTestElement(
-                'foreach: items, selection: { data: allItems, selection: selection, focused: focused, anchor: anchor }',
-                'attr: { id: id }, css: { selected: selected, focused: focused }'
-            );
-
-            items = createItems(20);
-            model.allItems = ko.observableArray(items);
-            model.items(items.slice(0, 10));
-            ko.applyBindings(model, element);
-            model.selection([items[4], items[11], items[15]]);
-        });
-
-        it('can have selected elements outside the shown elements', function () {
-            expect(element).to.have.selectionCount(1);
-            expect($('#item4')).to.have.cssClass('selected');
-            expect(items[11].selected()).to.ok();
-            expect(items[15].selected()).to.ok();
-            expect(model.selection().length).to.be(3);
-        });
-
-        it('can update the visible selection by clicking', function () {
-            click($('#item2'), { ctrlKey: true });
-
-            expect(element).to.have.selectionCount(2);
-            expect($('#item2')).to.have.cssClass('selected');
-            expect($('#item4')).to.have.cssClass('selected');
-            expect(items[11].selected()).to.ok();
-            expect(items[15].selected()).to.ok();
-            expect(model.selection().length).to.be(4);
-        });
-
-        it('selects everything on ctrl-a', function () {
-            keyDown($('ul', element), { ctrlKey: true, which: 65 });
-            expect(model.selection().length).to.be(20);
-        });
-    });
-
-    describe('in conditional rendering mode', function () {
-        beforeEach(function () {
-            element = createTestElement(
-                'foreach: items, selection: { selection: selection, focused: focused, anchor: anchor }',
-                'attr: { id: id }, css: { selected: selected, focused: focused }',
-                'if: items().length > 5'
-            );
-            ko.applyBindings(model, element);
-        });
-
-        describe('with selected items', function () {
-            beforeEach(function () {
-                model.select(7, 4, 2);
-                model.focusItem(2);
-                model.anchorItem(2);
-            });
-
-            it('maintains focus, anchor and selection when dropping below the display threshold', function () {
-                model.items(model.items.slice(0, 5));
-                expect(model.selection().length).to.be(2);
-                expect(model.focused()).to.be(model.items()[2]);
-                expect(model.anchor()).to.be(model.items()[2]);
-            });
-
-            it('cleans up focus, anchor and selection state when removing all items from the collection', function () {
-                model.items([0]);
-                expect(model.selection().length).to.be(0);
-                expect(model.focused()).to.not.be.ok();
-                expect(model.anchor()).to.not.be.ok();
-            });
-        });
-    });
-
-    describe('input data cleanup', function () {
-        it('removes items from selection on init when they do not exist in the data source', function (done) {
-            element = createTestElement(
-                'foreach: items, selection: { selection: selection, focused: focused, anchor: anchor }',
-                'attr: { id: id }, css: { selected: selected, focused: focused }'
-            );
-
-            var extraItems = createItems(1);
-            extraItems[0].selected(true);
-            model.selection.push(extraItems[0]);
-
-            ko.applyBindings(model, element);
-            setTimeout(function () {
-                expect(model.selection().length).to.be(0);
-                expect(extraItems[0].selected()).to.be(false);
-                done();
-            }, 5);
-        });
-    });
-
-    describe('error handling', function () {
-        it('throws if the selection-binding is not used together with a foreach-binding or a template-binding', function () {
-            element = createTestElement(
-                'selection: { selection: selection, focused: focused, anchor: anchor }',
-                'attr: { id: id }, css: { selected: selected, focused: focused }'
-            );
-            expect(function () {
+                items = createItems(20);
+                model.allItems = ko.observableArray(items);
+                model.items(items.slice(0, 10));
                 ko.applyBindings(model, element);
-            }).to.throwException(/used together with `foreach`/);
+                model.selection([items[4], items[11], items[15]]);
+            });
+
+            it('can have selected elements outside the shown elements', function () {
+                expect(element).to.have.selectionCount(1);
+                expect($('#item4')).to.have.cssClass('selected');
+                expect(items[11].selected()).to.ok();
+                expect(items[15].selected()).to.ok();
+                expect(model.selection().length).to.be(3);
+            });
+
+            it('can update the visible selection by clicking', function () {
+                specHelper.click($('#item2'), { ctrlKey: true });
+
+                expect(element).to.have.selectionCount(2);
+                expect($('#item2')).to.have.cssClass('selected');
+                expect($('#item4')).to.have.cssClass('selected');
+                expect(items[11].selected()).to.ok();
+                expect(items[15].selected()).to.ok();
+                expect(model.selection().length).to.be(4);
+            });
+
+            it('selects everything on ctrl-a', function () {
+                specHelper.keyDown($('ul', element), { ctrlKey: true, which: 65 });
+                expect(model.selection().length).to.be(20);
+            });
         });
 
-        it('throws when data is not an observable array', function () {
-            element = createTestElement(
+        describe('in conditional rendering mode', function () {
+            beforeEach(function () {
+                element = specHelper.createTestElement(
+                    'foreach: items, selection: { selection: selection, focused: focused, anchor: anchor }',
+                    'attr: { id: id }, css: { selected: selected, focused: focused }',
+                    'if: items().length > 5'
+                );
+                ko.applyBindings(model, element);
+            });
+
+            describe('with selected items', function () {
+                beforeEach(function () {
+                    model.select(7, 4, 2);
+                    model.focusItem(2);
+                    model.anchorItem(2);
+                });
+
+                it('maintains focus, anchor and selection when dropping below the display threshold', function () {
+                    model.items(model.items.slice(0, 5));
+                    expect(model.selection().length).to.be(2);
+                    expect(model.focused()).to.be(model.items()[2]);
+                    expect(model.anchor()).to.be(model.items()[2]);
+                });
+
+                it('cleans up focus, anchor and selection state when removing all items from the collection', function () {
+                    model.items([0]);
+                    expect(model.selection().length).to.be(0);
+                    expect(model.focused()).to.not.be.ok();
+                    expect(model.anchor()).to.not.be.ok();
+                });
+            });
+        });
+
+        describe('input data cleanup', function () {
+            it('removes items from selection on init when they do not exist in the data source', function (done) {
+                element = specHelper.createTestElement(
+                    'foreach: items, selection: { selection: selection, focused: focused, anchor: anchor }',
+                    'attr: { id: id }, css: { selected: selected, focused: focused }'
+                );
+
+                var extraItems = createItems(1);
+                extraItems[0].selected(true);
+                model.selection.push(extraItems[0]);
+
+                ko.applyBindings(model, element);
+                setTimeout(function () {
+                    expect(model.selection().length).to.be(0);
+                    expect(extraItems[0].selected()).to.be(false);
+                    done();
+                }, 5);
+            });
+        });
+
+        describe('error handling', function () {
+            it('throws if the selection-binding is not used together with a foreach-binding or a template-binding', function () {
+                element = specHelper.createTestElement(
+                    'selection: { selection: selection, focused: focused, anchor: anchor }',
+                    'attr: { id: id }, css: { selected: selected, focused: focused }'
+                );
+                expect(function () {
+                    ko.applyBindings(model, element);
+                }).to.throwException(/used together with `foreach`/);
+            });
+
+            it('throws when data is not an observable array', function () {
+                element = specHelper.createTestElement(
+                    "foreach: items, selection: { selection: selection, mode: 'single', focused: focused, anchor: anchor }",
+                    'attr: { id: id }, css: { selected: selected }'
+                );
+                model.selection = [];
+                expect(function () {
+                    ko.applyBindings(model, element);
+                }).to.throwException(/a object containing a `selection` `observableArray`/);
+            });
+
+            it('throws when binding value is not an observable array', function () {
+                element = specHelper.createTestElement(
+                    'foreach: items, selection: selection',
+                    'attr: { id: id }, css: { selected: selected }'
+                );
+                model.selection = [];
+                expect(function () {
+                    ko.applyBindings(model, element);
+                }).to.throwException(/a object containing a `selection` `observableArray`/);
+            });
+
+            it('throws when attempting to use an undefined selection mode', function () {
+                element = specHelper.createTestElement(
+                    "foreach: items, selection: { selection: selection, mode: 'nonExistingModeName' }",
+                    'attr: { id: id }, css: { selected: selected }'
+                );
+                model.selection = ko.observableArray([]);
+                expect(function () {
+                    ko.applyBindings(model, element);
+                }).to.throwException(/Unknown mode: "nonExistingModeName"/);
+            });
+        });
+
+        it('handles nested scoping', function () {
+            element = specHelper.createTestElement(
                 "foreach: items, selection: { selection: selection, mode: 'single', focused: focused, anchor: anchor }",
-                'attr: { id: id }, css: { selected: selected }'
-            );
-            model.selection = [];
-            expect(function () {
-                ko.applyBindings(model, element);
-            }).to.throwException(/a object containing a `selection` `observableArray`/);
-        });
-
-        it('throws when binding value is not an observable array', function () {
-            element = createTestElement(
-                'foreach: items, selection: selection',
-                'attr: { id: id }, css: { selected: selected }'
-            );
-            model.selection = [];
-            expect(function () {
-                ko.applyBindings(model, element);
-            }).to.throwException(/a object containing a `selection` `observableArray`/);
-        });
-
-        it('throws when attempting to use an undefined selection mode', function () {
-            element = createTestElement(
-                "foreach: items, selection: { selection: selection, mode: 'nonExistingModeName' }",
-                'attr: { id: id }, css: { selected: selected }'
-            );
-            model.selection = ko.observableArray([]);
-            expect(function () {
-                ko.applyBindings(model, element);
-            }).to.throwException(/Unknown mode: "nonExistingModeName"/);
-        });
-    });
-
-    it('handles nested scoping', function () {
-        element = createTestElement(
-            "foreach: items, selection: { selection: selection, mode: 'single', focused: focused, anchor: anchor }",
-            'attr: { id: id }, css: { selected: selected }, foreach: [0, 1, 2]'
-        );
-
-        $('li', element).each(function (index, el) {
-            $(el).append('<span data-bind="text: $data"></span>');
-        });
-
-        ko.applyBindings(model, element);
-        click($('#item3 span:first-child'));
-        expect(element).to.have.selectionCount(1);
-        expect($('#item3')).to.have.cssClass('selected');
-    });
-
-    describe('when switching mode', function () {
-        var items;
-        beforeEach(function () {
-            element = createTestElement(
-                'foreach: items, selection: { selection: selection, focused: focused, anchor: anchor, mode: mode }',
-                'attr: { id: id }, css: { selected: selected, focused: focused }'
+                'attr: { id: id }, css: { selected: selected }, foreach: [0, 1, 2]'
             );
 
-            items = createItems(20);
-            model.items = ko.observableArray(items);
-            model.mode = ko.observable('multi');
+            $('li', element).each(function (index, el) {
+                $(el).append('<span data-bind="text: $data"></span>');
+            });
+
             ko.applyBindings(model, element);
+            specHelper.click($('#item3 span:first-child'));
+            expect(element).to.have.selectionCount(1);
+            expect($('#item3')).to.have.cssClass('selected');
         });
 
-        it('switching to single mode, from multi with an active selection of 3 items should result in only the focused item being in the single mode selection.', function () {
-            model.mode('multi');
-            model.selection([items[4], items[11], items[15]]);
-            model.mode('single');
+        describe('when switching mode', function () {
+            var items;
+            beforeEach(function () {
+                element = specHelper.createTestElement(
+                    'foreach: items, selection: { selection: selection, focused: focused, anchor: anchor, mode: mode }',
+                    'attr: { id: id }, css: { selected: selected, focused: focused }'
+                );
 
-            expect(model.selection().length).to.be(1);
-        });
+                items = createItems(20);
+                model.items = ko.observableArray(items);
+                model.mode = ko.observable('multi');
+                ko.applyBindings(model, element);
+            });
 
-        it('verify that single mode works as expected when changing modes from multi mode.', function () {
-            model.mode('multi');
-            model.selection([items[4], items[11], items[15]]);
-            model.mode('single');
+            it('switching to single mode, from multi with an active selection of 3 items should result in only the focused item being in the single mode selection.', function () {
+                model.mode('multi');
+                model.selection([items[4], items[11], items[15]]);
+                model.mode('single');
 
-            click($('#item2'), { ctrlKey: true });
+                expect(model.selection().length).to.be(1);
+            });
 
-            expect(model.selection().length).to.be(1);
-        });
+            it('verify that single mode works as expected when changing modes from multi mode.', function () {
+                model.mode('multi');
+                model.selection([items[4], items[11], items[15]]);
+                model.mode('single');
 
-        it('verify that multi mode works as expected when changing modes from single mode.', function () {
-            model.mode('single');
-            model.selection([items[0]]);
-            model.mode('multi');
+                specHelper.click($('#item2'), { ctrlKey: true });
 
-            click($('#item1'), { ctrlKey: true });
+                expect(model.selection().length).to.be(1);
+            });
 
-            expect(model.selection().length).to.be(2);
-        });
+            it('verify that multi mode works as expected when changing modes from single mode.', function () {
+                model.mode('single');
+                model.selection([items[0]]);
+                model.mode('multi');
 
-        it('switching to a non existing mode fails', function () {
-            expect(function () {
-                model.mode('nonExistingModeName');
-            }).to.throwException(/Unknown mode: "nonExistingModeName"/);
+                specHelper.click($('#item1'), { ctrlKey: true });
+
+                expect(model.selection().length).to.be(2);
+            });
+
+            it('switching to a non existing mode fails', function () {
+                expect(function () {
+                    model.mode('nonExistingModeName');
+                }).to.throwException(/Unknown mode: "nonExistingModeName"/);
+            });
         });
     });
 });

--- a/test/knockout.selection.spec.js
+++ b/test/knockout.selection.spec.js
@@ -2,8 +2,13 @@
 defineTest([
     'jquery',
     'knockout',
-    'test/spec.helper'
-], function ($, ko, specHelper) {
+    'test/spec.helper',
+    'unexpected'
+], function ($, ko, specHelper, unexpected) {
+    var expect = unexpected.clone();
+
+    specHelper.installInto(expect);
+
     function createItems(size) {
         var result = [];
 
@@ -67,16 +72,16 @@ defineTest([
                 beforeEach(function () {
                     model.select(7);
                     model.focusItem(7);
-                    expect(element).to.have.selectionCount(1);
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('empties its selection when the observableArray bound to the foreach changes', function () {
                     model.items = ko.observableArray(createItems(9));
                     model.itemsWrappedInAnObservable(model.items);
-                    expect(model.selection().length).to.be(0);
-                    expect(element).to.have.selectionCount(0);
-                    expect(model.focused()).to.not.be.ok();
-                    expect(model.anchor()).to.not.be.ok();
+                    expect(model.selection().length, 'to be', 0);
+                    expect(element, 'to have selection count', 0);
+                    expect(model.focused(), 'to be falsy');
+                    expect(model.anchor(), 'to be falsy');
                 });
             });
         });
@@ -92,57 +97,57 @@ defineTest([
 
             describe('with no selection', function () {
                 it('has no elements marked as selected', function () {
-                    expect(element).to.have.selectionCount(0);
+                    expect(element, 'to have selection count', 0);
                 });
 
                 it('selects the clicked element', function () {
                     specHelper.click($('#item3'));
-                    expect(element).to.have.selectionCount(1);
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('select focused element on space', function () {
                     model.focusItem(3);
                     specHelper.space($('ul', element));
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item3'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects the element after the focused element on down-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowDown($('ul', element));
-                    expect($('#item4')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item4'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects the element before the focused element on up-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowUp($('ul', element));
-                    expect($('#item2')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item2'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects first element on down-arrow when there is no focused item', function () {
                     specHelper.arrowDown($('ul', element));
-                    expect($('#item0')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item0'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects first element on up-arrow when there is no focused item', function () {
                     specHelper.arrowUp($('ul', element));
-                    expect($('#item0')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item0'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects first element on home', function () {
                     specHelper.home($('ul', element));
-                    expect($('#item0')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item0'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects last element on end', function () {
                     specHelper.end($('ul', element));
-                    expect($('#item9')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item9'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 describe('when first element is focused', function () {
@@ -152,8 +157,8 @@ defineTest([
 
                     it('selects the focused element on up-arrow', function () {
                         specHelper.arrowUp($('ul', element));
-                        expect($('#item0')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item0'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
                 });
 
@@ -164,8 +169,8 @@ defineTest([
 
                     it('selects the focused element on down-arrow', function () {
                         specHelper.arrowDown($('ul', element));
-                        expect($('#item9')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item9'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
                 });
 
@@ -174,15 +179,15 @@ defineTest([
                     it('selects one item manually', function () {
                         model.selection([model.items()[3]]);
 
-                        expect($('#item3')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item3'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
 
                     it('selects multiple items manually', function () {
                         model.selection([model.items()[3], model.items()[9]]);
 
-                        expect(element).to.have.selectionCount(1);
-                        expect($('#item9')).to.have.cssClass('selected');
+                        expect(element, 'to have selection count', 1);
+                        expect($('#item9'), 'to have css class', 'selected');
                     });
 
                 });
@@ -195,101 +200,101 @@ defineTest([
                 });
 
                 it('has one selection', function () {
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item7')).to.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item7'), 'to have css class', 'selected');
                 });
 
                 it('moves the selection to the clicked element', function () {
                     specHelper.click($('#item3'));
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect($('#item7')).to.not.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item3'), 'to have css class', 'selected');
+                    expect($('#item7'), 'not to have css class', 'selected');
                 });
 
                 it('ignores clicks on selected element', function () {
                     specHelper.click($('#item7'));
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item7')).to.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item7'), 'to have css class', 'selected');
                 });
 
                 it('ignores shift', function () {
                     specHelper.click($('#item3'), { shiftKey: true });
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect($('#item4')).to.not.have.cssClass('selected');
-                    expect($('#item7')).to.not.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item3'), 'to have css class', 'selected');
+                    expect($('#item4'), 'not to have css class', 'selected');
+                    expect($('#item7'), 'not to have css class', 'selected');
                 });
 
                 it('ignores ctrl', function () {
                     specHelper.click($('#item3'), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect($('#item7')).to.not.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item3'), 'to have css class', 'selected');
+                    expect($('#item7'), 'not to have css class', 'selected');
                 });
 
                 it('selects next element on down-arrow', function () {
                     specHelper.arrowDown($('ul', element));
-                    expect($('#item7')).to.not.have.cssClass('selected');
-                    expect($('#item8')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item7'), 'not to have css class', 'selected');
+                    expect($('#item8'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects previous element on up-arrow', function () {
                     specHelper.arrowUp($('ul', element));
-                    expect($('#item7')).to.not.have.cssClass('selected');
-                    expect($('#item6')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item7'), 'not to have css class', 'selected');
+                    expect($('#item6'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('deselects item on space', function () {
                     specHelper.space($('ul', element));
-                    expect($('#item7')).to.not.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(0);
+                    expect($('#item7'), 'not to have css class', 'selected');
+                    expect(element, 'to have selection count', 0);
                 });
 
                 it('selects first element on home', function () {
                     specHelper.home($('ul', element));
-                    expect($('#item0')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item0'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects last element on end', function () {
                     specHelper.end($('ul', element));
-                    expect($('#item9')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item9'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('keeps its selection and focused item after one of the unselected items is removed from the observable array', function () {
                     model.items.remove(model.getItem(6));
-                    expect(model.focused()).to.be.ok();
-                    expect(element).to.have.selectionCount(1);
-                    expect(model.selection().length).to.be(1);
+                    expect(model.focused(), 'to be truthy');
+                    expect(element, 'to have selection count', 1);
+                    expect(model.selection().length, 'to be', 1);
                 });
 
                 it('has no selection after the selected item is removed from the observable array', function () {
                     model.items.remove(model.getItem(7));
-                    expect(element).to.have.selectionCount(0);
-                    expect(model.selection().length).to.be(0);
+                    expect(element, 'to have selection count', 0);
+                    expect(model.selection().length, 'to be', 0);
                 });
 
                 it('focuses the item at the same index after the focused item is removed from the observable array', function () {
                     model.items.remove(model.getItem(7));
-                    expect(model.focused()).to.be(model.getItem(7));
-                    expect(model.focused().id).to.be('item8');
+                    expect(model.focused(), 'to be', model.getItem(7));
+                    expect(model.focused().id, 'to be', 'item8');
                 });
 
                 it('focuses the new last item if the last item was focused and removed from the observable array', function () {
                     model.focusItem(9);
                     model.items.remove(model.getItem(9));
-                    expect(model.focused()).to.be(model.getItem(8));
-                    expect(model.focused().id).to.be('item8');
+                    expect(model.focused(), 'to be', model.getItem(8));
+                    expect(model.focused().id, 'to be', 'item8');
                 });
 
                 it('has its anchor observable set to null after the anchor item is removed from the observable array', function () {
                     model.anchorItem(7);
-                    expect(model.anchor()).to.be.ok();
+                    expect(model.anchor(), 'to be truthy');
                     model.items.remove(model.getItem(7));
-                    expect(model.anchor()).to.not.be.ok();
+                    expect(model.anchor(), 'to be falsy');
                 });
 
                 describe('when the selection is set manually', function () {
@@ -297,15 +302,15 @@ defineTest([
                     it('selects one item manually', function () {
                         model.selection([model.items()[3]]);
 
-                        expect($('#item3')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item3'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
 
                     it('selects multiple items manually', function () {
                         model.selection([model.items()[3], model.items()[9]]);
 
-                        expect(element).to.have.selectionCount(1);
-                        expect($('#item9')).to.have.cssClass('selected');
+                        expect(element, 'to have selection count', 1);
+                        expect($('#item9'), 'to have css class', 'selected');
                     });
 
                 });
@@ -315,16 +320,16 @@ defineTest([
                     it('keeps items selected when they are still in foreach', function () {
                         model.items(model.items().slice(5));
 
-                        expect(element).to.have.selectionCount(1);
-                        expect($('#item7')).to.have.cssClass('selected');
-                        expect(model.selection().length).to.be(1);
+                        expect(element, 'to have selection count', 1);
+                        expect($('#item7'), 'to have css class', 'selected');
+                        expect(model.selection().length, 'to be', 1);
                     });
 
                     it('removes items from selection when they are removed from foreach', function () {
                         model.items(model.items().slice(0, 4));
 
-                        expect(element).to.have.selectionCount(0);
-                        expect(model.selection().length).to.be(0);
+                        expect(element, 'to have selection count', 0);
+                        expect(model.selection().length, 'to be', 0);
                     });
                 });
             });
@@ -332,8 +337,8 @@ defineTest([
             it('focuses selected element', function () {
                 specHelper.click($('#item3'));
                 var focused = model.focused();
-                expect(focused.id).to.be('item3');
-                expect(focused.focused()).to.be.ok();
+                expect(focused.id, 'to be', 'item3');
+                expect(focused.focused(), 'to be truthy');
             });
         });
 
@@ -350,27 +355,27 @@ defineTest([
                 it('selects the element after the focused element on right-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowRight($('ul', element));
-                    expect($('#item4')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item4'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects the element before the focused element on left-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowLeft($('ul', element));
-                    expect($('#item2')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item2'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects the first element on right-arrow when there is no focus', function () {
                     specHelper.arrowRight($('ul', element));
-                    expect($('#item0')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item0'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects the first element on left-arrow when there is no focus', function () {
                     specHelper.arrowLeft($('ul', element));
-                    expect($('#item0')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item0'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 describe('when first element is focused', function () {
@@ -380,8 +385,8 @@ defineTest([
 
                     it('selects the focused element on left-arrow', function () {
                         specHelper.arrowLeft($('ul', element));
-                        expect($('#item0')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item0'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
                 });
 
@@ -392,8 +397,8 @@ defineTest([
 
                     it('selects the focused element on right-arrow', function () {
                         specHelper.arrowRight($('ul', element));
-                        expect($('#item9')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item9'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
                 });
             });
@@ -406,16 +411,16 @@ defineTest([
 
                 it('selects next element on right-arrow', function () {
                     specHelper.arrowRight($('ul', element));
-                    expect($('#item7')).to.not.have.cssClass('selected');
-                    expect($('#item8')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item7'), 'not to have css class', 'selected');
+                    expect($('#item8'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects previous element on left-arrow', function () {
                     specHelper.arrowLeft($('ul', element));
-                    expect($('#item7')).to.not.have.cssClass('selected');
-                    expect($('#item6')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item7'), 'not to have css class', 'selected');
+                    expect($('#item6'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
             });
         });
@@ -431,19 +436,19 @@ defineTest([
 
             describe('with no selection', function () {
                 it('has no elements marked as selected', function () {
-                    expect(element).to.have.selectionCount(0);
+                    expect(element, 'to have selection count', 0);
                 });
 
                 it('selects the clicked element', function () {
                     specHelper.click($('#item3'));
-                    expect(element).to.have.selectionCount(1);
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('select focused element on space', function () {
                     model.focusItem(3);
                     specHelper.space($('ul', element));
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item3'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
             });
 
@@ -454,17 +459,17 @@ defineTest([
                 });
 
                 it('should have one selected item', function () {
-                    expect(element).to.have.selectionCount(1);
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects another item', function () {
                     specHelper.click($('#item3'));
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                 });
 
                 it('deselects an item by selecting it', function () {
                     specHelper.click($('#item7'));
-                    expect(element).to.have.selectionCount(0);
+                    expect(element, 'to have selection count', 0);
                 });
             });
         });
@@ -480,18 +485,18 @@ defineTest([
 
             describe('with no selection', function () {
                 it('has no elements marked as selected', function () {
-                    expect(element).to.have.selectionCount(0);
+                    expect(element, 'to have selection count', 0);
                 });
 
                 it('does not select the clicked element', function () {
                     specHelper.click($('#item3'));
-                    expect(element).to.have.selectionCount(0);
+                    expect(element, 'to have selection count', 0);
                 });
 
                 it('does not select focused element on space', function () {
                     model.focusItem(3);
                     specHelper.space($('ul', element));
-                    expect(element).to.have.selectionCount(0);
+                    expect(element, 'to have selection count', 0);
                 });
             });
 
@@ -502,17 +507,17 @@ defineTest([
                 });
 
                 it('should have one selected item', function () {
-                    expect(element).to.have.selectionCount(1);
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('should not select another item', function () {
                     specHelper.click($('#item3'));
-                    expect(element).to.have.selectionCount(1);
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('should not deselect an item by selecting it', function () {
                     specHelper.click($('#item7'));
-                    expect(element).to.have.selectionCount(1);
+                    expect(element, 'to have selection count', 1);
                 });
             });
         });
@@ -536,93 +541,93 @@ defineTest([
 
             describe('with no selection', function () {
                 it('has no elements marked as selected', function () {
-                    expect(element).to.have.selectionCount(0);
+                    expect(element, 'to have selection count', 0);
                 });
 
                 it('selects the clicked element', function () {
                     specHelper.click($('#item3'));
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item3')).to.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item3'), 'to have css class', 'selected');
                 });
 
                 it('selects the clicked element on shift-click', function () {
                     specHelper.click($('#item3'), { shiftKey: true });
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item3')).to.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item3'), 'to have css class', 'selected');
                 });
 
                 it('selects the clicked element on ctrl-click', function () {
                     specHelper.click($('#item3'), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item3')).to.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item3'), 'to have css class', 'selected');
                 });
 
                 it('select focused element on space', function () {
                     model.focusItem(3);
                     specHelper.space($('ul', element));
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item3'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects first element on home', function () {
                     specHelper.home($('ul', element));
-                    expect($('#item0')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item0'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects last element on end', function () {
                     specHelper.end($('ul', element));
-                    expect($('#item9')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item9'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects the element after the focused element on down-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowDown($('ul', element));
-                    expect($('#item4')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item4'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects the element before the focused element on up-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowUp($('ul', element));
-                    expect($('#item2')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item2'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects first element on up-arrow when there is no focused element', function () {
                     specHelper.arrowUp($('ul', element));
-                    expect($('#item0')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item0'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects first element on down-arrow when there is no focused element', function () {
                     specHelper.arrowDown($('ul', element));
-                    expect($('#item0')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item0'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects and focuses the element after the focused element on shift-down-arrow', function () {
                     model.focusItem(3);
                     model.anchorItem(3);
                     specHelper.arrowDown($('ul', element), { shiftKey: true });
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect($('#item4')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(2);
+                    expect($('#item3'), 'to have css class', 'selected');
+                    expect($('#item4'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 2);
                 });
 
                 it('selects and focuses the element before the focused element on shift-up-arrow', function () {
                     model.focusItem(3);
                     model.anchorItem(3);
                     specHelper.arrowUp($('ul', element), { shiftKey: true });
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect($('#item2')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(2);
+                    expect($('#item3'), 'to have css class', 'selected');
+                    expect($('#item2'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 2);
                 });
 
                 it('selects everything on ctrl-a', function () {
                     specHelper.keyDown($('ul', element), { ctrlKey: true, which: 65 });
-                    expect(element).to.have.selectionCount(10);
+                    expect(element, 'to have selection count', 10);
                 });
 
                 describe('when first element is focused', function () {
@@ -632,8 +637,8 @@ defineTest([
 
                     it('selects the focused element on up-arrow', function () {
                         specHelper.arrowUp($('ul', element));
-                        expect($('#item0')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item0'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
                 });
 
@@ -644,8 +649,8 @@ defineTest([
 
                     it('selects the focused element on down-arrow', function () {
                         specHelper.arrowDown($('ul', element));
-                        expect($('#item9')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item9'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
                 });
 
@@ -654,16 +659,16 @@ defineTest([
                     it('selects one item manually', function () {
                         model.selection([model.items()[3]]);
 
-                        expect($('#item3')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item3'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
 
                     it('selects multiple items manually', function () {
                         model.selection([model.items()[3], model.items()[9]]);
 
-                        expect(element).to.have.selectionCount(2);
-                        expect($('#item3')).to.have.cssClass('selected');
-                        expect($('#item9')).to.have.cssClass('selected');
+                        expect(element, 'to have selection count', 2);
+                        expect($('#item3'), 'to have css class', 'selected');
+                        expect($('#item9'), 'to have css class', 'selected');
                     });
 
                 });
@@ -678,17 +683,17 @@ defineTest([
 
                 it('expands the selection with ctrl-click', function () {
                     specHelper.click($('#item3'), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(4);
+                    expect(element, 'to have selection count', 4);
                     [2, 3, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('deselected selected items with ctrl-click', function () {
                     specHelper.click($('#item4'), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                     [2, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
@@ -696,76 +701,76 @@ defineTest([
                     model.focusItem(6);
                     specHelper.space($('ul', element));
                     [2, 4, 6, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
-                    expect(element).to.have.selectionCount(4);
+                    expect(element, 'to have selection count', 4);
                 });
 
                 it('ignores ctrl key on space', function () {
                     model.focusItem(6);
                     specHelper.space($('ul', element), { ctrlKey: true });
                     [2, 4, 6, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
-                    expect(element).to.have.selectionCount(4);
+                    expect(element, 'to have selection count', 4);
                 });
 
                 it('ignores shift key on space', function () {
                     model.focusItem(6);
                     specHelper.space($('ul', element), { shiftKey: true });
                     [2, 4, 6, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
-                    expect(element).to.have.selectionCount(4);
+                    expect(element, 'to have selection count', 4);
                 });
 
                 it('maintains the selection of non-focused, but selected, elements on space', function () {
                     specHelper.space($('ul', element));
                     [4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                 });
 
                 it('expands the selection with shift-click', function () {
                     specHelper.click($('#item5'), { shiftKey: true });
-                    expect(element).to.have.selectionCount(4);
+                    expect(element, 'to have selection count', 4);
                     [2, 3, 4, 5].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('expands the selection downward on shift-down-arrow', function () {
                     specHelper.arrowDown($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                     [2, 3].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('expands the selection further downward on successive shift-down-arrow', function () {
                     specHelper.arrowDown($('ul', element), { shiftKey: true });
                     specHelper.arrowDown($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 3, 4].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('expands the selection upward on shift-up-arrow', function () {
                     specHelper.arrowUp($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                     [1, 2].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('expands the selection further upward on successive shift-up-arrow', function () {
                     specHelper.arrowUp($('ul', element), { shiftKey: true });
                     specHelper.arrowUp($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [0, 1, 2].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
@@ -774,35 +779,35 @@ defineTest([
                     specHelper.arrowDown($('ul', element), { shiftKey: true });
                     specHelper.arrowUp($('ul', element), { shiftKey: true });
                     specHelper.arrowDown($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 3, 4].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('maintains the selection on ctrl-down-arrow', function () {
                     specHelper.arrowDown($('ul', element), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('maintains the selection on successive ctrl-down-arrow', function () {
                     specHelper.arrowDown($('ul', element), { ctrlKey: true });
                     specHelper.arrowDown($('ul', element), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('moves the selection anchor downwards on ctrl-down-arrow', function () {
                     specHelper.arrowDown($('ul', element), { ctrlKey: true });
                     specHelper.arrowDown($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                     [3, 4].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
@@ -810,46 +815,46 @@ defineTest([
                     specHelper.arrowDown($('ul', element), { ctrlKey: true });
                     specHelper.arrowDown($('ul', element), { ctrlKey: true });
                     specHelper.arrowDown($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                     [4, 5].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('maintains the selection on ctrl-up-arrow', function () {
                     specHelper.arrowUp($('ul', element), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('maintains the selection on successive ctrl-up-arrow', function () {
                     specHelper.arrowUp($('ul', element), { ctrlKey: true });
                     specHelper.arrowUp($('ul', element), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('moves the selection anchor upward on ctrl-up-arrow', function () {
                     specHelper.arrowUp($('ul', element), { ctrlKey: true });
 
-                    expect(model.anchor().id).to.be('item1');
+                    expect(model.anchor().id, 'to be', 'item1');
                 });
 
                 it('moves the selection anchor further upward on successive ctrl-up-arrow', function () {
                     specHelper.arrowUp($('ul', element), { ctrlKey: true });
                     specHelper.arrowUp($('ul', element), { ctrlKey: true });
-                    expect(model.anchor().id).to.be('item0');
+                    expect(model.anchor().id, 'to be', 'item0');
                 });
 
                 it('moves the selection anchor on successive ctrl-up/down-arrow', function () {
                     specHelper.arrowDown($('ul', element), { ctrlKey: true });
                     specHelper.arrowDown($('ul', element), { ctrlKey: true });
                     specHelper.arrowUp($('ul', element), { ctrlKey: true });
-                    expect(model.anchor().id).to.be('item3');
+                    expect(model.anchor().id, 'to be', 'item3');
                 });
 
                 it('maintains selection on successive ctrl-up/down-arrow', function () {
@@ -858,55 +863,55 @@ defineTest([
                     specHelper.arrowUp($('ul', element), { ctrlKey: true });
 
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                 });
 
                 it('selects all items from anchor to top on shift-home', function () {
                     specHelper.home($('ul', element), { shiftKey: true });
 
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [0, 1, 2].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('selects all items from anchor to bottom on shift-end', function () {
                     specHelper.end($('ul', element), { shiftKey: true });
 
-                    expect(element).to.have.selectionCount(8);
+                    expect(element, 'to have selection count', 8);
                     [2, 3, 4, 5, 6, 7, 8, 9].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('moves the selection anchor to top on ctrl-home', function () {
                     specHelper.home($('ul', element), { ctrlKey: true });
-                    expect(model.anchor().id).to.be('item0');
+                    expect(model.anchor().id, 'to be', 'item0');
 
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('moves the selection anchor to bottom on ctrl-end', function () {
                     specHelper.end($('ul', element), { ctrlKey: true });
-                    expect(model.anchor().id).to.be('item9');
+                    expect(model.anchor().id, 'to be', 'item9');
 
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('expands selection with range from anchor to top on ctrl-shift-home', function () {
                     specHelper.home($('ul', element), { ctrlKey: true, shiftKey: true });
 
-                    expect(element).to.have.selectionCount(5);
+                    expect(element, 'to have selection count', 5);
                     [0, 1, 2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
@@ -915,64 +920,64 @@ defineTest([
                     model.anchorItem(6);
                     specHelper.end($('ul', element), { ctrlKey: true, shiftKey: true });
 
-                    expect(element).to.have.selectionCount(6);
+                    expect(element, 'to have selection count', 6);
                     [2, 4, 6, 7, 8, 9].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('removes the selection and selects next element on down-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowDown($('ul', element));
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item4')).to.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item4'), 'to have css class', 'selected');
                 });
 
                 it('removes the selection and selects previous element on up-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowUp($('ul', element));
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item2')).to.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item2'), 'to have css class', 'selected');
                 });
 
                 it('removes the selection and selects clicked item on mouse click', function () {
                     model.focusItem(3);
                     specHelper.click($('#item8'));
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item8')).to.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item8'), 'to have css class', 'selected');
                 });
 
                 it('keeps its selection count after one of the unselected items is removed from the observable array', function () {
                     model.items.remove(model.getItem(6));
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                 });
 
                 it('has its selection count decremented after one of selected items is removed from the observable array', function () {
                     model.items.remove(model.getItem(7));
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                 });
 
                 it('has its selection count decremented after the focused and selected item is removed from the observable array', function () {
                     model.items.remove(model.getItem(2));
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                 });
 
                 it('focuses the item at the same index after the focused item is removed from the observable array', function () {
                     model.items.remove(model.getItem(2));
-                    expect(model.focused()).to.be(model.getItem(2));
-                    expect(model.focused().id).to.be('item3');
+                    expect(model.focused(), 'to be', model.getItem(2));
+                    expect(model.focused().id, 'to be', 'item3');
                 });
 
                 it('focuses the new last item if the last item was focused and removed from the observable array', function () {
                     model.focusItem(9);
                     model.items.remove(model.getItem(9));
-                    expect(model.focused()).to.be(model.getItem(8));
-                    expect(model.focused().id).to.be('item8');
+                    expect(model.focused(), 'to be', model.getItem(8));
+                    expect(model.focused().id, 'to be', 'item8');
                 });
 
                 it('has its anchor observable set to null after the anchor item is removed from the observable array', function () {
                     model.items.remove(model.getItem(2));
-                    expect(model.anchor()).to.not.be.ok();
+                    expect(model.anchor(), 'to be falsy');
                 });
 
                 it('is possible to cancel the selection event if the item is alreay selected', function () {
@@ -984,11 +989,11 @@ defineTest([
                     var anchor = model.anchor();
 
                     specHelper.click($('#item4'));
-                    expect(focused).to.be(model.focused());
-                    expect(anchor).to.be(model.anchor());
-                    expect(element).to.have.selectionCount(3);
+                    expect(focused, 'to be', model.focused());
+                    expect(anchor, 'to be', model.anchor());
+                    expect(element, 'to have selection count', 3);
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
@@ -997,16 +1002,16 @@ defineTest([
                     it('selects one item manually', function () {
                         model.selection([model.items()[3]]);
 
-                        expect($('#item3')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item3'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
 
                     it('selects multiple items manually', function () {
                         model.selection([model.items()[3], model.items()[9]]);
 
-                        expect(element).to.have.selectionCount(2);
-                        expect($('#item3')).to.have.cssClass('selected');
-                        expect($('#item9')).to.have.cssClass('selected');
+                        expect(element, 'to have selection count', 2);
+                        expect($('#item3'), 'to have css class', 'selected');
+                        expect($('#item9'), 'to have css class', 'selected');
                     });
                 });
 
@@ -1015,19 +1020,19 @@ defineTest([
                     it('keeps items selected when they are still in the foreach', function () {
                         model.items(model.items().slice(2, 8));
 
-                        expect(element).to.have.selectionCount(3);
+                        expect(element, 'to have selection count', 3);
                         [2, 4, 7].forEach(function (index) {
-                            expect($('#item' + index)).to.have.cssClass('selected');
+                            expect($('#item' + index), 'to have css class', 'selected');
                         });
-                        expect(model.selection().length).to.be(3);
+                        expect(model.selection().length, 'to be', 3);
                     });
 
                     it('removes items from selection when they are removed from foreach', function () {
                         model.items(model.items().slice(5));
 
-                        expect(element).to.have.selectionCount(1);
-                        expect($('#item7')).to.have.cssClass('selected');
-                        expect(model.selection().length).to.be(1);
+                        expect(element, 'to have selection count', 1);
+                        expect($('#item7'), 'to have css class', 'selected');
+                        expect(model.selection().length, 'to be', 1);
                     });
                 });
 
@@ -1038,21 +1043,21 @@ defineTest([
                         });
 
                         it('unselects the item', function () {
-                            expect($('#item7')).not.to.have.cssClass('selected');
+                            expect($('#item7'), 'not to have css class', 'selected');
                         });
 
                         it('does not change the selection of the other items', function () {
-                            expect(element).to.have.selectionCount(2);
-                            expect($('#item2')).to.have.cssClass('selected');
-                            expect($('#item4')).to.have.cssClass('selected');
+                            expect(element, 'to have selection count', 2);
+                            expect($('#item2'), 'to have css class', 'selected');
+                            expect($('#item4'), 'to have css class', 'selected');
                         });
 
                         it('sets the item as the focus', function () {
-                            expect(model.focused().id).to.be('item7');
+                            expect(model.focused().id, 'to be', 'item7');
                         });
 
                         it('sets the item as the anchor', function () {
-                            expect(model.anchor().id).to.be('item7');
+                            expect(model.anchor().id, 'to be', 'item7');
                         });
                     });
 
@@ -1062,19 +1067,19 @@ defineTest([
                         });
 
                         it('selects the item in addition to the current selection', function () {
-                            expect(element).to.have.selectionCount(4);
-                            expect($('#item3')).to.have.cssClass('selected');
-                            expect($('#item2')).to.have.cssClass('selected');
-                            expect($('#item4')).to.have.cssClass('selected');
-                            expect($('#item7')).to.have.cssClass('selected');
+                            expect(element, 'to have selection count', 4);
+                            expect($('#item3'), 'to have css class', 'selected');
+                            expect($('#item2'), 'to have css class', 'selected');
+                            expect($('#item4'), 'to have css class', 'selected');
+                            expect($('#item7'), 'to have css class', 'selected');
                         });
 
                         it('sets the item as the focus', function () {
-                            expect(model.focused().id).to.be('item3');
+                            expect(model.focused().id, 'to be', 'item3');
                         });
 
                         it('sets the item as the anchor', function () {
-                            expect(model.anchor().id).to.be('item3');
+                            expect(model.anchor().id, 'to be', 'item3');
                         });
                     });
                 });
@@ -1086,15 +1091,15 @@ defineTest([
                 });
 
                 it('selects the item', function () {
-                    expect($('#item7')).to.have.cssClass('selected');
+                    expect($('#item7'), 'to have css class', 'selected');
                 });
 
                 it('sets the item as the focus', function () {
-                    expect(model.focused().id).to.be('item7');
+                    expect(model.focused().id, 'to be', 'item7');
                 });
 
                 it('sets the item as the anchor', function () {
-                    expect(model.anchor().id).to.be('item7');
+                    expect(model.anchor().id, 'to be', 'item7');
                 });
             });
 
@@ -1104,27 +1109,27 @@ defineTest([
                 });
 
                 it('selects the item', function () {
-                    expect($('#item7')).to.have.cssClass('selected');
+                    expect($('#item7'), 'to have css class', 'selected');
                 });
 
                 it('sets the item as the focus', function () {
-                    expect(model.focused().id).to.be('item7');
+                    expect(model.focused().id, 'to be', 'item7');
                 });
 
                 it('sets the item as the anchor', function () {
-                    expect(model.anchor().id).to.be('item7');
+                    expect(model.anchor().id, 'to be', 'item7');
                 });
             });
 
             describe('clicking on elements that have the toggleClass', function () {
                 it('sets the item as the focus', function () {
                     specHelper.click($('#item7 .checkbox'));
-                    expect(model.focused().id).to.be('item7');
+                    expect(model.focused().id, 'to be', 'item7');
                 });
 
                 it('sets the item as the anchor', function () {
                     specHelper.click($('#item7 .checkbox'));
-                    expect(model.anchor().id).to.be('item7');
+                    expect(model.anchor().id, 'to be', 'item7');
                 });
             });
 
@@ -1133,16 +1138,16 @@ defineTest([
                     return model.items()[index];
                 }));
 
-                expect(element).to.have.selectionCount(4);
+                expect(element, 'to have selection count', 4);
                 [2, 3, 4, 7].forEach(function (index) {
-                    expect($('#item' + index)).to.have.cssClass('selected');
+                    expect($('#item' + index), 'to have css class', 'selected');
                 });
             });
 
             it('updates the DOM when the focus changes', function () {
                 model.focused(model.items()[4]);
-                expect(element).to.have.selectionCount(0);
-                expect($('#item4')).to.have.cssClass('focused');
+                expect(element, 'to have selection count', 0);
+                expect($('#item4'), 'to have css class', 'focused');
             });
 
             it('updates selected field of items when the selection data is changed', function () {
@@ -1153,7 +1158,7 @@ defineTest([
                 var selectionCount = model.items().reduce(function (result, item) {
                     return result + item.selected();
                 }, 0);
-                expect(selectionCount).to.be(4);
+                expect(selectionCount, 'to be', 4);
             });
 
             it('updates focused field of the items when the focus changes', function () {
@@ -1161,8 +1166,8 @@ defineTest([
                 var focusCount = model.items().reduce(function (result, item) {
                     return result + item.focused();
                 }, 0);
-                expect(focusCount).to.be(1);
-                expect(model.items()[4].focused()).to.be.ok();
+                expect(focusCount, 'to be', 1);
+                expect(model.items()[4].focused(), 'to be truthy');
             });
         });
 
@@ -1179,33 +1184,33 @@ defineTest([
                 it('selects the element after the focused element on right-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowRight($('ul', element));
-                    expect($('#item4')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item4'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects the element before the focused element on left-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowLeft($('ul', element));
-                    expect($('#item2')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(1);
+                    expect($('#item2'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 1);
                 });
 
                 it('selects and focuses the element after the focused element on shift-right-arrow', function () {
                     model.focusItem(3);
                     model.anchorItem(3);
                     specHelper.arrowRight($('ul', element), { shiftKey: true });
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect($('#item4')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(2);
+                    expect($('#item3'), 'to have css class', 'selected');
+                    expect($('#item4'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 2);
                 });
 
                 it('selects and focuses the element before the focused element on shift-left-arrow', function () {
                     model.focusItem(3);
                     model.anchorItem(3);
                     specHelper.arrowLeft($('ul', element), { shiftKey: true });
-                    expect($('#item3')).to.have.cssClass('selected');
-                    expect($('#item2')).to.have.cssClass('selected');
-                    expect(element).to.have.selectionCount(2);
+                    expect($('#item3'), 'to have css class', 'selected');
+                    expect($('#item2'), 'to have css class', 'selected');
+                    expect(element, 'to have selection count', 2);
                 });
 
                 describe('when first element is focused', function () {
@@ -1215,8 +1220,8 @@ defineTest([
 
                     it('selects the focused element on left-arrow', function () {
                         specHelper.arrowLeft($('ul', element));
-                        expect($('#item0')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item0'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
                 });
 
@@ -1227,8 +1232,8 @@ defineTest([
 
                     it('selects the focused element on right-arrow', function () {
                         specHelper.arrowRight($('ul', element));
-                        expect($('#item9')).to.have.cssClass('selected');
-                        expect(element).to.have.selectionCount(1);
+                        expect($('#item9'), 'to have css class', 'selected');
+                        expect(element, 'to have selection count', 1);
                     });
                 });
             });
@@ -1242,35 +1247,35 @@ defineTest([
 
                 it('expands the selection downward on shift-right-arrow', function () {
                     specHelper.arrowRight($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                     [2, 3].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('expands the selection further downward on successive shift-right-arrow', function () {
                     specHelper.arrowRight($('ul', element), { shiftKey: true });
                     specHelper.arrowRight($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 3, 4].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('expands the selection upward on shift-left-arrow', function () {
                     specHelper.arrowLeft($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                     [1, 2].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('expands the selection further upward on successive shift-left-arrow', function () {
                     specHelper.arrowLeft($('ul', element), { shiftKey: true });
                     specHelper.arrowLeft($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [0, 1, 2].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
@@ -1279,35 +1284,35 @@ defineTest([
                     specHelper.arrowRight($('ul', element), { shiftKey: true });
                     specHelper.arrowLeft($('ul', element), { shiftKey: true });
                     specHelper.arrowRight($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 3, 4].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('maintains the selection on ctrl-right-arrow', function () {
                     specHelper.arrowRight($('ul', element), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('maintains the selection on successive ctrl-right-arrow', function () {
                     specHelper.arrowRight($('ul', element), { ctrlKey: true });
                     specHelper.arrowRight($('ul', element), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('moves the selection anchor downwards on ctrl-right-arrow', function () {
                     specHelper.arrowRight($('ul', element), { ctrlKey: true });
                     specHelper.arrowRight($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                     [3, 4].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
@@ -1315,46 +1320,46 @@ defineTest([
                     specHelper.arrowRight($('ul', element), { ctrlKey: true });
                     specHelper.arrowRight($('ul', element), { ctrlKey: true });
                     specHelper.arrowRight($('ul', element), { shiftKey: true });
-                    expect(element).to.have.selectionCount(2);
+                    expect(element, 'to have selection count', 2);
                     [4, 5].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('maintains the selection on ctrl-left-arrow', function () {
                     specHelper.arrowLeft($('ul', element), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('maintains the selection on successive ctrl-left-arrow', function () {
                     specHelper.arrowLeft($('ul', element), { ctrlKey: true });
                     specHelper.arrowLeft($('ul', element), { ctrlKey: true });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
                 });
 
                 it('moves the selection anchor upward on ctrl-left-arrow', function () {
                     specHelper.arrowLeft($('ul', element), { ctrlKey: true });
 
-                    expect(model.anchor().id).to.be('item1');
+                    expect(model.anchor().id, 'to be', 'item1');
                 });
 
                 it('moves the selection anchor further upward on successive ctrl-left-arrow', function () {
                     specHelper.arrowLeft($('ul', element), { ctrlKey: true });
                     specHelper.arrowLeft($('ul', element), { ctrlKey: true });
-                    expect(model.anchor().id).to.be('item0');
+                    expect(model.anchor().id, 'to be', 'item0');
                 });
 
                 it('moves the selection anchor on successive ctrl-left/right-arrow', function () {
                     specHelper.arrowRight($('ul', element), { ctrlKey: true });
                     specHelper.arrowRight($('ul', element), { ctrlKey: true });
                     specHelper.arrowLeft($('ul', element), { ctrlKey: true });
-                    expect(model.anchor().id).to.be('item3');
+                    expect(model.anchor().id, 'to be', 'item3');
                 });
 
                 it('maintains selection on successive ctrl-left/right-arrow', function () {
@@ -1363,23 +1368,23 @@ defineTest([
                     specHelper.arrowLeft($('ul', element), { ctrlKey: true });
 
                     [2, 4, 7].forEach(function (index) {
-                        expect($('#item' + index)).to.have.cssClass('selected');
+                        expect($('#item' + index), 'to have css class', 'selected');
                     });
-                    expect(element).to.have.selectionCount(3);
+                    expect(element, 'to have selection count', 3);
                 });
 
                 it('removes the selection and selects next element on right-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowRight($('ul', element));
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item4')).to.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item4'), 'to have css class', 'selected');
                 });
 
                 it('removes the selection and selects previous element on left-arrow', function () {
                     model.focusItem(3);
                     specHelper.arrowLeft($('ul', element));
-                    expect(element).to.have.selectionCount(1);
-                    expect($('#item2')).to.have.cssClass('selected');
+                    expect(element, 'to have selection count', 1);
+                    expect($('#item2'), 'to have css class', 'selected');
                 });
             });
         });
@@ -1400,27 +1405,27 @@ defineTest([
             });
 
             it('can have selected elements outside the shown elements', function () {
-                expect(element).to.have.selectionCount(1);
-                expect($('#item4')).to.have.cssClass('selected');
-                expect(items[11].selected()).to.ok();
-                expect(items[15].selected()).to.ok();
-                expect(model.selection().length).to.be(3);
+                expect(element, 'to have selection count', 1);
+                expect($('#item4'), 'to have css class', 'selected');
+                expect(items[11].selected(), 'to be truthy');
+                expect(items[15].selected(), 'to be truthy');
+                expect(model.selection().length, 'to be', 3);
             });
 
             it('can update the visible selection by clicking', function () {
                 specHelper.click($('#item2'), { ctrlKey: true });
 
-                expect(element).to.have.selectionCount(2);
-                expect($('#item2')).to.have.cssClass('selected');
-                expect($('#item4')).to.have.cssClass('selected');
-                expect(items[11].selected()).to.ok();
-                expect(items[15].selected()).to.ok();
-                expect(model.selection().length).to.be(4);
+                expect(element, 'to have selection count', 2);
+                expect($('#item2'), 'to have css class', 'selected');
+                expect($('#item4'), 'to have css class', 'selected');
+                expect(items[11].selected(), 'to be truthy');
+                expect(items[15].selected(), 'to be truthy');
+                expect(model.selection().length, 'to be', 4);
             });
 
             it('selects everything on ctrl-a', function () {
                 specHelper.keyDown($('ul', element), { ctrlKey: true, which: 65 });
-                expect(model.selection().length).to.be(20);
+                expect(model.selection().length, 'to be', 20);
             });
         });
 
@@ -1443,16 +1448,16 @@ defineTest([
 
                 it('maintains focus, anchor and selection when dropping below the display threshold', function () {
                     model.items(model.items.slice(0, 5));
-                    expect(model.selection().length).to.be(2);
-                    expect(model.focused()).to.be(model.items()[2]);
-                    expect(model.anchor()).to.be(model.items()[2]);
+                    expect(model.selection().length, 'to be', 2);
+                    expect(model.focused(), 'to be', model.items()[2]);
+                    expect(model.anchor(), 'to be', model.items()[2]);
                 });
 
                 it('cleans up focus, anchor and selection state when removing all items from the collection', function () {
                     model.items([0]);
-                    expect(model.selection().length).to.be(0);
-                    expect(model.focused()).to.not.be.ok();
-                    expect(model.anchor()).to.not.be.ok();
+                    expect(model.selection().length, 'to be', 0);
+                    expect(model.focused(), 'to be falsy');
+                    expect(model.anchor(), 'to be falsy');
                 });
             });
         });
@@ -1470,8 +1475,8 @@ defineTest([
 
                 ko.applyBindings(model, element);
                 setTimeout(function () {
-                    expect(model.selection().length).to.be(0);
-                    expect(extraItems[0].selected()).to.be(false);
+                    expect(model.selection().length, 'to be', 0);
+                    expect(extraItems[0].selected(), 'to be', false);
                     done();
                 }, 5);
             });
@@ -1485,7 +1490,7 @@ defineTest([
                 );
                 expect(function () {
                     ko.applyBindings(model, element);
-                }).to.throwException(/used together with `foreach`/);
+                }, 'to throw', /used together with `foreach`/);
             });
 
             it('throws when data is not an observable array', function () {
@@ -1496,7 +1501,7 @@ defineTest([
                 model.selection = [];
                 expect(function () {
                     ko.applyBindings(model, element);
-                }).to.throwException(/a object containing a `selection` `observableArray`/);
+                }, 'to throw', /a object containing a `selection` `observableArray`/);
             });
 
             it('throws when binding value is not an observable array', function () {
@@ -1507,7 +1512,7 @@ defineTest([
                 model.selection = [];
                 expect(function () {
                     ko.applyBindings(model, element);
-                }).to.throwException(/a object containing a `selection` `observableArray`/);
+                }, 'to throw', /a object containing a `selection` `observableArray`/);
             });
 
             it('throws when attempting to use an undefined selection mode', function () {
@@ -1518,7 +1523,7 @@ defineTest([
                 model.selection = ko.observableArray([]);
                 expect(function () {
                     ko.applyBindings(model, element);
-                }).to.throwException(/Unknown mode: "nonExistingModeName"/);
+                }, 'to throw', /Unknown mode: "nonExistingModeName"/);
             });
         });
 
@@ -1534,8 +1539,8 @@ defineTest([
 
             ko.applyBindings(model, element);
             specHelper.click($('#item3 span:first-child'));
-            expect(element).to.have.selectionCount(1);
-            expect($('#item3')).to.have.cssClass('selected');
+            expect(element, 'to have selection count', 1);
+            expect($('#item3'), 'to have css class', 'selected');
         });
 
         describe('when switching mode', function () {
@@ -1557,7 +1562,7 @@ defineTest([
                 model.selection([items[4], items[11], items[15]]);
                 model.mode('single');
 
-                expect(model.selection().length).to.be(1);
+                expect(model.selection().length, 'to be', 1);
             });
 
             it('verify that single mode works as expected when changing modes from multi mode.', function () {
@@ -1567,7 +1572,7 @@ defineTest([
 
                 specHelper.click($('#item2'), { ctrlKey: true });
 
-                expect(model.selection().length).to.be(1);
+                expect(model.selection().length, 'to be', 1);
             });
 
             it('verify that multi mode works as expected when changing modes from single mode.', function () {
@@ -1577,13 +1582,13 @@ defineTest([
 
                 specHelper.click($('#item1'), { ctrlKey: true });
 
-                expect(model.selection().length).to.be(2);
+                expect(model.selection().length, 'to be', 2);
             });
 
             it('switching to a non existing mode fails', function () {
                 expect(function () {
                     model.mode('nonExistingModeName');
-                }).to.throwException(/Unknown mode: "nonExistingModeName"/);
+                }, 'to throw', /Unknown mode: "nonExistingModeName"/);
             });
         });
     });

--- a/test/phantomjs.html
+++ b/test/phantomjs.html
@@ -8,7 +8,6 @@
     <div id="mocha"></div>
     <div style="display: none" id="test"></div>
 
-    <script src="../vendor/expect.js"></script>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="requirejs-mocha.js"></script>
 
@@ -17,7 +16,8 @@
             baseUrl: '..',
             paths: {
                 jquery: 'vendor/jquery-1.10.2',
-                knockout: 'vendor/knockout-3.0.0.debug'
+                knockout: 'vendor/knockout-3.0.0.debug',
+                unexpected: 'node_modules/unexpected/unexpected'
             }
         };
     </script>

--- a/test/phantomjs.html
+++ b/test/phantomjs.html
@@ -10,16 +10,18 @@
 
     <script src="../vendor/expect.js"></script>
     <script src="../node_modules/mocha/mocha.js"></script>
-    <script src="../vendor/jquery-1.10.2.js"></script>
-    <script src="../vendor/knockout-3.0.0.debug.js"></script>
-    <script src="../lib/eventmatcher.js"></script>
-    <script src="../lib/knockout.selection.js"></script>
-    <script>mocha.ui('bdd');</script>
-    <script src="spec.helper.js"></script>
-    <script src="knockout.selection.spec.js"></script>
-    <script src="eventmatcher.spec.js"></script>
+    <script src="requirejs-mocha.js"></script>
+
     <script>
-        mochaPhantomJS.run();
+        var require = {
+            baseUrl: '..',
+            paths: {
+                jquery: 'vendor/jquery-1.10.2',
+                knockout: 'vendor/knockout-3.0.0.debug'
+            }
+        };
     </script>
+
+    <script src="../node_modules/requirejs/require.js" data-main="test/runner"></script>
   </body>
 </html>

--- a/test/requirejs-mocha.js
+++ b/test/requirejs-mocha.js
@@ -1,0 +1,17 @@
+/*global define*/
+window.defineTestSuite = function (tests) {
+    define(tests, function () {
+        for (var i = 0; i < arguments.length; i += 1) {
+            arguments[i]();
+        }
+    });
+};
+
+window.defineTest = function (dependencies, test) {
+    define(dependencies, function () {
+        var args = arguments;
+        return function () {
+            return test.apply(null, args);
+        };
+    });
+};

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,0 +1,22 @@
+/*global mocha, mochaPhantomJS, require, after, beforeEach*/
+if (window.mochaPhantomJS) {
+    mocha.ui('bdd').reporter(Mocha.BrowserStack);
+} else {
+    mocha.ui('bdd');
+}
+
+mocha.reporter('html');
+
+require([
+    'jquery',
+    'test/suite',
+    'lib/knockout.selection'
+], function ($) {
+    mocha.globals('jQuery*'); // HACK: Need better way to allow handlers on window during tests.
+
+    if (window.mochaPhantomJS) {
+        mochaPhantomJS.run();
+    } else {
+        mocha.run();
+    }
+});

--- a/test/spec.helper.js
+++ b/test/spec.helper.js
@@ -1,7 +1,8 @@
 /*global beforeEach, expect*/
 define([
-    'jquery'
-], function ($) {
+    'jquery',
+    'unexpected'
+], function ($, unexpected) {
     function SpecHelper() {
     };
 
@@ -98,28 +99,20 @@ define([
         return Array.prototype.slice.call(args);
     }
 
-    beforeEach(function () {
-        expect.Assertion.prototype.cssClass = function (expected) {
-            var $element = $(this.obj);
+    SpecHelper.prototype.installInto = function (expect) {
+        expect.addAssertion('[not] to have css class', function (expect, subject, className) {
+            var $element = $(subject);
             var elementClasses = ($element.attr('class') || '').split(' ');
 
-            this.obj = elementClasses;
-            this.contain(expected);
+            expect(elementClasses, '[not] to contain', className);
+        });
 
-            return this;
-        };
+        expect.addAssertion('to have selection count', function (expect, subject, selectionCount) {
+            var actualCount = $('.selected', subject).length;
 
-        expect.Assertion.prototype.selectionCount = function (expected) {
-            var selectionCount = $('.selected', this.obj).length;
-
-            this.assert(
-                selectionCount === expected,
-                function () { return 'expected list to have ' + expected + ' selected items but got ' + selectionCount; },
-                function () { return 'expected list to not have ' + expected + ' selected items but got ' + selectionCount; });
-
-            return this;
-        };
-    });
+            expect(selectionCount, 'to equal', actualCount);
+        });
+    };
 
     var specHelper = new SpecHelper();
 

--- a/test/spec.helper.js
+++ b/test/spec.helper.js
@@ -1,116 +1,127 @@
-/*global $, beforeEach, expect*/
-function createTestElement(listBindings, itemBindings, parentBinding) {
-    var testContainer = $('#test'),
-    elementContainer = $('<div></div>'),
-    list = $('<ul tabindex="-1"></ul>');
+/*global beforeEach, expect*/
+define([
+    'jquery'
+], function ($) {
+    function SpecHelper() {
+    };
 
-    if (parentBinding) {
-        elementContainer.attr('data-bind', parentBinding);
+    SpecHelper.prototype.createTestElement = function (listBindings, itemBindings, parentBinding) {
+        var testContainer = $('#test'),
+            elementContainer = $('<div></div>'),
+            list = $('<ul tabindex="-1"></ul>');
+
+        if (parentBinding) {
+            elementContainer.attr('data-bind', parentBinding);
+        }
+
+        list.attr('data-bind', listBindings);
+        elementContainer.append(list);
+
+        if (itemBindings) {
+            var item = $('<li></li>');
+
+            item.attr('data-bind', itemBindings);
+            list.append(item);
+        }
+
+        testContainer.empty();
+        testContainer.append(elementContainer);
+
+        return elementContainer.get(0);
     }
 
-    list.attr('data-bind', listBindings);
-    elementContainer.append(list);
-
-    if (itemBindings) {
-        var item = $('<li></li>');
-
-        item.attr('data-bind', itemBindings);
-        list.append(item);
+    SpecHelper.prototype.click = function (element, options) {
+        var defaultOptions = {
+            which: 1,
+            shiftKey: false,
+            ctrlKey: false
+        };
+        options = $.extend(defaultOptions, options);
+        element.trigger($.Event("mousedown", options));
+        element.trigger($.Event("mouseup", options));
+        element.trigger($.Event("click", options));
     }
 
-    testContainer.empty();
-    testContainer.append(elementContainer);
+    SpecHelper.prototype.keyDown = function (element, options) {
+        var defaultOptions = {
+            shiftKey: false,
+            ctrlKey: false
+        };
+        options = $.extend(defaultOptions, options);
+        var e = $.Event("keydown", options);
+        element.trigger(e);
+    }
 
-    return elementContainer.get(0);
-}
+    SpecHelper.prototype.arrowDown = function (element, options) {
+        var defaultOptions = { which: 40 };
+        options = $.extend(defaultOptions, options);
+        this.keyDown(element, options);
+    }
 
-function click(element, options) {
-    var defaultOptions = {
-        which: 1,
-        shiftKey: false,
-        ctrlKey: false
-    };
-    options = $.extend(defaultOptions, options);
-    element.trigger($.Event("mousedown", options));
-    element.trigger($.Event("mouseup", options));
-    element.trigger($.Event("click", options));
-}
+    SpecHelper.prototype.arrowRight = function (element, options) {
+        var defaultOptions = { which: 39 };
+        options = $.extend(defaultOptions, options);
+        this.keyDown(element, options);
+    }
 
-function keyDown(element, options) {
-    var defaultOptions = {
-        shiftKey: false,
-        ctrlKey: false
-    };
-    options = $.extend(defaultOptions, options);
-    var e = $.Event("keydown", options);
-    element.trigger(e);
-}
+    SpecHelper.prototype.arrowUp = function (element, options) {
+        var defaultOptions = { which: 38 };
+        options = $.extend(defaultOptions, options);
+        this.keyDown(element, options);
+    }
 
-function arrowDown(element, options) {
-    var defaultOptions = { which: 40 };
-    options = $.extend(defaultOptions, options);
-    keyDown(element, options);
-}
+    SpecHelper.prototype.arrowLeft = function (element, options) {
+        var defaultOptions = { which: 37 };
+        options = $.extend(defaultOptions, options);
+        this.keyDown(element, options);
+    }
 
-function arrowRight(element, options) {
-    var defaultOptions = { which: 39 };
-    options = $.extend(defaultOptions, options);
-    keyDown(element, options);
-}
+    SpecHelper.prototype.space = function (element, options) {
+        var defaultOptions = { which: 32 };
+        options = $.extend(defaultOptions, options);
+        this.keyDown(element, options);
+    }
 
-function arrowUp(element, options) {
-    var defaultOptions = { which: 38 };
-    options = $.extend(defaultOptions, options);
-    keyDown(element, options);
-}
+    SpecHelper.prototype.home = function (element, options) {
+        var defaultOptions = { which: 36 };
+        options = $.extend(defaultOptions, options);
+        this.keyDown(element, options);
+    }
 
-function arrowLeft(element, options) {
-    var defaultOptions = { which: 37 };
-    options = $.extend(defaultOptions, options);
-    keyDown(element, options);
-}
+    SpecHelper.prototype.end = function (element, options) {
+        var defaultOptions = { which: 35 };
+        options = $.extend(defaultOptions, options);
+        this.keyDown(element, options);
+    }
 
-function space(element, options) {
-    var defaultOptions = { which: 32 };
-    options = $.extend(defaultOptions, options);
-    keyDown(element, options);
-}
+    SpecHelper.prototype.toArray = function (args) {
+        return Array.prototype.slice.call(args);
+    }
 
-function home(element, options) {
-    var defaultOptions = { which: 36 };
-    options = $.extend(defaultOptions, options);
-    keyDown(element, options);
-}
+    beforeEach(function () {
+        expect.Assertion.prototype.cssClass = function (expected) {
+            var $element = $(this.obj);
+            var elementClasses = ($element.attr('class') || '').split(' ');
 
-function end(element, options) {
-    var defaultOptions = { which: 35 };
-    options = $.extend(defaultOptions, options);
-    keyDown(element, options);
-}
+            this.obj = elementClasses;
+            this.contain(expected);
 
-function toArray(args) {
-    return Array.prototype.slice.call(args);
-}
+            return this;
+        };
 
-beforeEach(function () {
-    expect.Assertion.prototype.cssClass = function (expected) {
-        var $element = $(this.obj);
-        var elementClasses = ($element.attr('class') || '').split(' ');
+        expect.Assertion.prototype.selectionCount = function (expected) {
+            var selectionCount = $('.selected', this.obj).length;
 
-        this.obj = elementClasses;
-        this.contain(expected);
+            this.assert(
+                selectionCount === expected,
+                function () { return 'expected list to have ' + expected + ' selected items but got ' + selectionCount; },
+                function () { return 'expected list to not have ' + expected + ' selected items but got ' + selectionCount; });
 
-        return this;
-    };
+            return this;
+        };
+    });
 
-    expect.Assertion.prototype.selectionCount = function (expected) {
-        var selectionCount = $('.selected', this.obj).length;
+    var specHelper = new SpecHelper();
 
-        this.assert(
-            selectionCount === expected,
-            function () { return 'expected list to have ' + expected + ' selected items but got ' + selectionCount; },
-            function () { return 'expected list to not have ' + expected + ' selected items but got ' + selectionCount; });
-
-        return this;
-    };
+    return specHelper;
 });

--- a/test/suite.js
+++ b/test/suite.js
@@ -1,0 +1,5 @@
+/*global defineTestSuite*/
+defineTestSuite([
+    'test/knockout.selection.spec',
+    'test/eventmatcher.spec'
+]);


### PR DESCRIPTION
I updated the test suite to use unexpected instead of expect.js, which could allow for some nicer tests and integration with 'unexpected' plugins, such as unexpected-dom.
Bundled with this PR is using requirejs as the test suite loader, to try to limit the need for globals in the test suite.